### PR TITLE
Add definition and template for default role configuration

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -192,6 +192,30 @@ checkmk_server__wato_aux_tags:
     wato: True
 
 
+# .. envvar:: checkmk_server__multisite_roles
+#
+# Multisite permission roles to be configured
+checkmk_server__multisite_roles: '{{ checkmk_server__default_roles }}'
+
+
+# .. envvar:: checkmk_server__default_roles
+#
+# Default upstream multisite permission roles
+checkmk_server__default_roles:
+  admin:
+    alias: 'Administrator'
+    builtin: True
+    permissions: {}
+  guest:
+    alias: 'Guest User'
+    builtin: True
+    permissions: {}
+  user:
+    alias: 'Normal monitoring user'
+    builtin: True
+    permissions: {}
+
+
 # ----------------
 # Monitoring Rules
 # ----------------

--- a/tasks/site.yml
+++ b/tasks/site.yml
@@ -128,6 +128,15 @@
   register: checkmk_server_register_ssh_pubkey
   when: checkmk_server__sshkeys|d()
 
+- name: Generate multisite permission roles definition
+  template:
+    src: 'etc/check_mk/multisite.d/wato/roles.mk.j2'
+    dest: '{{ checkmk_server__site_home }}/{{ checkmk_server__multisite_config_path }}/wato/roles.mk'
+    owner: '{{ checkmk_server__user }}'
+    group: '{{ checkmk_server__group }}'
+    mode: '0644'
+  tags: [ 'role::checkmk_server:multisite' ]
+
 - name: Generate Check_MK WATO multisite definitions
   template:
     src: '{{ lookup("template_src", "etc/check_mk/multisite.d/wato/" + item | basename) }}'

--- a/templates/etc/check_mk/multisite.d/wato/roles.mk.j2
+++ b/templates/etc/check_mk/multisite.d/wato/roles.mk.j2
@@ -1,0 +1,6 @@
+# {{ ansible_managed }}
+# encoding: utf-8
+
+roles.update(
+{ {% for role, params in checkmk_server__multisite_roles|dictsort %}'{{ role }}': {{ params | replace("u'", "'") }}{% if not loop.last %},
+  {% endif %}{% endfor %} })


### PR DESCRIPTION
This also allows to specify custom roles. For example:

```
# Define default roles and custom role
checkmk_server__multisite_roles: '{{ checkmk_server__default_roles |
                                     combine(checkmk_server__custom_roles,
                                             recursive=True) }}'

# Custom role based on the 'user' role with additional 'see_all' permission
checkmk_server__custom_roles:
  myuser:
    alias: 'Custom User'
    builtin: False
    basedon: 'user'
    permissions:
      general.see_all: True
```
