### PR TITLE
Add support for local user management

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -222,6 +222,18 @@ checkmk_server__default_roles:
 checkmk_server__multisite_users: {}
 
 
+# .. envvar:: checkmk_server__multisite_user_defaults
+#
+# Default user properties set for local users defined in
+# :envvar:`checkmk_server__multisite_users`
+checkmk_server__multisite_user_defaults:
+  force_authuser: False
+  force_authuser_webservice: False
+  locked: False
+  roles: [ 'user' ]
+  start_url: 'dashboard.py'
+
+
 # ----------------
 # Monitoring Rules
 # ----------------

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -218,7 +218,8 @@ checkmk_server__default_roles:
 
 # .. envvar:: checkmk_server__multisite_users
 #
-# Locally defined multisite users to be configured
+# Locally defined multisite users to be configured. See
+# :ref:`checkmk_server__multisite_users` for more information.
 checkmk_server__multisite_users: {}
 
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -216,6 +216,12 @@ checkmk_server__default_roles:
     permissions: {}
 
 
+# .. envvar:: checkmk_server__multisite_users
+#
+# Locally defined multisite users to be configured
+checkmk_server__multisite_users: {}
+
+
 # ----------------
 # Monitoring Rules
 # ----------------

--- a/docs/defaults-configuration.rst
+++ b/docs/defaults-configuration.rst
@@ -56,9 +56,16 @@ properties can be set via Ansible inventory:
   Full name, required.
 
 ``password``
-  Optional. Set given password in Apache :file:`htpasswd` file. Will be used
-  for form-based WATO authentication and Icinga, PNP4Nagios and NagVis HTTP
-  basic authentication.
+  Optional. Set given password in Apache :file:`htpasswd` file. Can be used
+  for form-based authentication in WATO and HTTP basic authentication in
+  Icinga, PNP4Nagios and NagVis.
+
+``automation_secret``
+  Optional. Automation secret for machine accounts. Set this instead of
+  ``item.password`` if the account is used for authentication of `WebAPI`_
+  calls.
+
+.. _WebAPI: https://mathias-kettner.com/checkmk_wato_webapi.html
 
 ``locked``
   Optional. Disable login to this account. Defaults to ``False``.

--- a/docs/defaults-configuration.rst
+++ b/docs/defaults-configuration.rst
@@ -37,3 +37,58 @@ following keys:
 ``publickey_file``
   Pre-generated SSH public key file. Must be the public key of the private
   key set with ``privatekey_file``.
+
+
+.. _checkmk_server__multisite_users:
+
+checkmk_server__multisite_users
+-------------------------------
+
+Configuration dictionary to define local WATO users. When running Ansible
+they are merged into the :file:`users.mk` user database of Check_MK. Users
+already defined in WATO or synchronized from an identity management system
+such as LDAP won't be overwritten.
+
+The dictionary key has to be the user name to create or manage. The following
+properties can be set via Ansible inventory:
+
+``alias``
+  Full name, required.
+
+``password``
+  Optional. Set given password in Apache :file:`htpasswd` file. Will be used
+  for form-based WATO authentication and Icinga, PNP4Nagios and NagVis HTTP
+  basic authentication.
+
+``locked``
+  Optional. Disable login to this account. Defaults to ``False``.
+
+``roles``
+  Optional. List of permission roles defined in
+  :envvar:`checkmk_server__multisite_roles`. Defaults to ``[ 'user' ]``.
+
+``force_authuser``
+  Optional. Only show hosts and services the user is a contact for. Defaults
+  to ``False``.
+
+``force_authuser_webservice``
+  Optional. Export only hosts and services the user is a contact for.
+  Defaults to ``False``.
+
+``start_url``
+  Optional. Start URL to display in main frame. Defaults to ``dashboard.py``.
+
+
+.. _checkmk_server__multisite_users_example:
+
+Example
+~~~~~~~
+
+Create custom administrator account with random password::
+
+    checkmk_server__multisite_users:
+
+      bob:
+        alias: 'Bob Admin'
+        password: '{{ lookup("password", "credentials/check_mk/" + checkmk_server__site + "/bob/password length=15") }}'
+        roles: [ 'admin' ]

--- a/tasks/site.yml
+++ b/tasks/site.yml
@@ -137,6 +137,19 @@
     mode: '0644'
   tags: [ 'role::checkmk_server:multisite' ]
 
+- name: Read local multisite users definition
+  command: 'sed "1,4d" {{ checkmk_server__site_home }}/{{ checkmk_server__multisite_config_path }}/wato/users.mk'
+  register: checkmk_server_register_users_mk
+  changed_when: False
+  always_run: True
+  tags: [ 'role::checkmk_server:multisite' ]
+
+- name: Set multisite users definition fact
+  set_fact:
+    checkmk_server_fact_local_users: '{{ checkmk_server_register_users_mk.stdout }}'
+  always_run: True
+  tags: [ 'role::checkmk_server:multisite' ]
+
 - name: Generate Check_MK WATO multisite definitions
   template:
     src: '{{ lookup("template_src", "etc/check_mk/multisite.d/wato/" + item | basename) }}'

--- a/tasks/site.yml
+++ b/tasks/site.yml
@@ -137,6 +137,11 @@
     mode: '0644'
   tags: [ 'role::checkmk_server:multisite' ]
 
+- name: Wait for the site to be started
+  wait_for:
+    path: '{{ checkmk_server__site_home }}/{{ checkmk_server__multisite_config_path }}/wato/users.mk'
+    timeout: 60
+
 - name: Read local multisite users definition
   command: 'sed "1,4d" {{ checkmk_server__site_home }}/{{ checkmk_server__multisite_config_path }}/wato/users.mk'
   register: checkmk_server_register_users_mk

--- a/tasks/site.yml
+++ b/tasks/site.yml
@@ -162,6 +162,7 @@
     password: '{{ checkmk_server__multisite_users[item]["password"] }}'
   when: '"password" in checkmk_server__multisite_users[item]'
   with_items: '{{ checkmk_server__multisite_users|list }}'
+  tags: [ 'role::checkmk_server:multisite' ]
 
 - name: Generate Check_MK WATO multisite definitions
   template:

--- a/tasks/site.yml
+++ b/tasks/site.yml
@@ -161,7 +161,7 @@
     name: '{{ item }}'
     password: '{{ checkmk_server__multisite_users[item]["password"] }}'
   when: '"password" in checkmk_server__multisite_users[item]'
-  with_items: '{{ checkmk_server__multisite_users|list }}'
+  with_items: '{{ checkmk_server__multisite_users|d({})|list }}'
   tags: [ 'role::checkmk_server:multisite' ]
 
 - name: Generate Check_MK WATO multisite definitions

--- a/tasks/site.yml
+++ b/tasks/site.yml
@@ -155,6 +155,14 @@
   always_run: True
   tags: [ 'role::checkmk_server:multisite' ]
 
+- name: Set local multisite user passwords
+  htpasswd:
+    path: '{{ checkmk_server__site_home }}/etc/htpasswd'
+    name: '{{ item }}'
+    password: '{{ checkmk_server__multisite_users[item]["password"] }}'
+  when: '"password" in checkmk_server__multisite_users[item]'
+  with_items: '{{ checkmk_server__multisite_users|list }}'
+
 - name: Generate Check_MK WATO multisite definitions
   template:
     src: '{{ lookup("template_src", "etc/check_mk/multisite.d/wato/" + item | basename) }}'

--- a/tasks/site.yml
+++ b/tasks/site.yml
@@ -162,6 +162,7 @@
     password: '{{ checkmk_server__multisite_users[item]["password"]
                   if "password" in checkmk_server__multisite_users[item]
                   else checkmk_server__multisite_users[item]["automation_secret"] }}'
+    crypt_scheme: md5_crypt
   when: ("password" in checkmk_server__multisite_users[item]) or
         ("automation_secret" in checkmk_server__multisite_users[item])
   with_items: '{{ checkmk_server__multisite_users|d({})|list }}'

--- a/tasks/site.yml
+++ b/tasks/site.yml
@@ -159,8 +159,11 @@
   htpasswd:
     path: '{{ checkmk_server__site_home }}/etc/htpasswd'
     name: '{{ item }}'
-    password: '{{ checkmk_server__multisite_users[item]["password"] }}'
-  when: '"password" in checkmk_server__multisite_users[item]'
+    password: '{{ checkmk_server__multisite_users[item]["password"]
+                  if "password" in checkmk_server__multisite_users[item]
+                  else checkmk_server__multisite_users[item]["automation_secret"] }}'
+  when: ("password" in checkmk_server__multisite_users[item]) or
+        ("automation_secret" in checkmk_server__multisite_users[item])
   with_items: '{{ checkmk_server__multisite_users|d({})|list }}'
   tags: [ 'role::checkmk_server:multisite' ]
 
@@ -170,7 +173,9 @@
     dest: '{{ checkmk_server__site_home }}/{{ checkmk_server__multisite_config_path }}/wato/{{ item | basename | replace(".j2", "") }}'
     owner: '{{ checkmk_server__user }}'
     group: '{{ checkmk_server__group }}'
-    mode: '0644'
+    mode: '{{ "0660"
+              if item | basename | replace(".j2", "") in [ "hosttags.mk", "users.mk" ]
+              else "0644" }}'
   with_fileglob: [ '../templates/etc/check_mk/multisite.d/wato/*.mk.j2' ]
   notify: [ 'Reload Check_MK configuration' ]
   tags: [ 'role::checkmk_server:rules', 'role::checkmk_server:multisite' ]

--- a/tasks/site.yml
+++ b/tasks/site.yml
@@ -143,7 +143,7 @@
     timeout: 60
 
 - name: Read local multisite users definition
-  command: 'sed "1,4d" {{ checkmk_server__site_home }}/{{ checkmk_server__multisite_config_path }}/wato/users.mk'
+  command: 'sed -e "1,/^multisite_users\s*=/d" {{ checkmk_server__site_home }}/{{ checkmk_server__multisite_config_path }}/wato/users.mk'
   register: checkmk_server_register_users_mk
   changed_when: False
   always_run: True

--- a/templates/etc/check_mk/multisite.d/wato/users.mk.j2
+++ b/templates/etc/check_mk/multisite.d/wato/users.mk.j2
@@ -1,3 +1,12 @@
+{% for user in checkmk_server__multisite_users|list|d([]) %}
+{#
+ # Strip Ansible-only properties from user definitions
+ #}
+{%   for property in checkmk_server__ansible_user_properties|d([]) %}
+{%     if property in checkmk_server__multisite_users[user]|list %}
+{%       set _ = checkmk_server__multisite_users[user].pop(property) %}
+{%     endif %}
+{%   endfor %}
 {#
  # Combine fact users with multisite users
  #}

--- a/templates/etc/check_mk/multisite.d/wato/users.mk.j2
+++ b/templates/etc/check_mk/multisite.d/wato/users.mk.j2
@@ -1,0 +1,12 @@
+{#
+ # Combine fact users with multisite users
+ #}
+{% set users = checkmk_server_fact_local_users|d({}) | combine(checkmk_server__multisite_users, recursive=True) %}
+# Written by Multisite UserDB
+# encoding: utf-8
+
+multisite_users = \
+{#
+ # Pretty print and fix that only alias strings are marked to be unicode strings
+ #}
+{{ users | pprint | regex_replace("([ :,][ \[\{])u'", "\\1'") | replace("'alias': '", "'alias': u'") }}

--- a/templates/etc/check_mk/multisite.d/wato/users.mk.j2
+++ b/templates/etc/check_mk/multisite.d/wato/users.mk.j2
@@ -14,7 +14,7 @@
  # rewriting users.mk in case of file modifications through Check_MK.
  #
  #}
-{% for user in checkmk_server__multisite_users|list|d([]) %}
+{% for user in checkmk_server__multisite_users|d({})|list %}
 {#
  # Strip Ansible-only properties from user definitions
  #}
@@ -26,7 +26,7 @@
 {#
  # Make sure default arguments are defined
  #}
-{%   for key, value in checkmk_server__multisite_user_defaults.iteritems() %}
+{%   for key, value in (checkmk_server__multisite_user_defaults|d({})).iteritems() %}
 {%     if user not in checkmk_server_fact_local_users|d({}) and key not in checkmk_server__multisite_users[user]|d({}) %}
 {%       set _ = checkmk_server__multisite_users[user].update({key: value}) %}
 {%     endif %}
@@ -35,7 +35,7 @@
 {#
  # Combine fact users with multisite users
  #}
-{% set users = checkmk_server_fact_local_users|d({}) | combine(checkmk_server__multisite_users, recursive=True) %}
+{% set users = checkmk_server_fact_local_users|d({}) | combine(checkmk_server__multisite_users|d({}), recursive=True) %}
 # Written by Multisite UserDB
 # encoding: utf-8
 

--- a/templates/etc/check_mk/multisite.d/wato/users.mk.j2
+++ b/templates/etc/check_mk/multisite.d/wato/users.mk.j2
@@ -8,6 +8,15 @@
 {%     endif %}
 {%   endfor %}
 {#
+ # Make sure default arguments are defined
+ #}
+{%   for key, value in checkmk_server__multisite_user_defaults.iteritems() %}
+{%     if user not in checkmk_server_fact_local_users|d({}) and key not in checkmk_server__multisite_users[user]|d({}) %}
+{%       set _ = checkmk_server__multisite_users[user].update({key: value}) %}
+{%     endif %}
+{%   endfor %}
+{% endfor %}
+{#
  # Combine fact users with multisite users
  #}
 {% set users = checkmk_server_fact_local_users|d({}) | combine(checkmk_server__multisite_users, recursive=True) %}

--- a/templates/etc/check_mk/multisite.d/wato/users.mk.j2
+++ b/templates/etc/check_mk/multisite.d/wato/users.mk.j2
@@ -1,3 +1,19 @@
+{#
+ # This template merges the users read from the original users.mk passed via
+ # ``checkmk_server_fact_local_users`` with the users defined in the Ansible
+ # inventory ``checkmk_server__multisite_users``. The merge is necessary as
+ # users from remote directories such as LDAP or Active Directory are written
+ # down to users.mk by Check_MK and obviously shouldn't be deleted by Ansible.
+ #
+ # The ``multisite_users`` variable in users.mk is a regular Python dictionary
+ # written down by ``save_users()`` in check_mk/web/htdocs/userdb.py. The
+ # user name and alias are unicode strings. All other strings are regular
+ # Python 2 strings.
+ #
+ # The template tries to imitate the original file formatting to avoid
+ # rewriting users.mk in case of file modifications through Check_MK.
+ #
+ #}
 {% for user in checkmk_server__multisite_users|list|d([]) %}
 {#
  # Strip Ansible-only properties from user definitions
@@ -25,6 +41,6 @@
 
 multisite_users = \
 {#
- # Pretty print and fix that only alias strings are marked to be unicode strings
+ # Pretty print dictionary and adapt unicode string hinting
  #}
 {{ users | pprint | regex_replace("([ :,][ \[\{])u'", "\\1'") | replace("'alias': '", "'alias': u'") }}

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -8,3 +8,6 @@ checkmk_server__group: '{{ checkmk_server__site }}'
 
 # Check_MK site chroot directory
 checkmk_server__site_home: '/opt/omd/sites/{{ checkmk_server__site }}'
+
+# Ansible user properties which are not set in the users.mk
+checkmk_server__ansible_user_properties: [ 'password' ]


### PR DESCRIPTION
This series of patches allows to define local Web users via Ansible inventory. As Check_MK also supports synchronization with directory services (LDAP, Active Directory), the users defined by Ansible have to be merged with the already available users in `users.mk`. Explicit support for the automation user profile is still missing and will be added in a later patch.
