### PR TITLE
Add support for LDAP user_connections configuration

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -235,6 +235,34 @@ checkmk_server__multisite_user_defaults:
   start_url: 'dashboard.py'
 
 
+# .. envvar:: checkmk_server__multisite_user_connections
+#
+# LDAP user synchronization connection settings. See
+# :ref:`checkmk_server__multisite_user_connections` for more information.
+checkmk_server__multisite_user_connections: []
+
+
+# .. envvar:: checkmk_server__multisite_user_connection_defaults
+#
+# Default properties set for LDAP user connections defined in
+# :envvar:`checkmk_server__multisite_user_connections`
+checkmk_server__multisite_user_connection_defaults:
+  active_plugins: {}
+  cache_livetime: 300
+  comment: ''
+  debug_log: False
+  description: ''
+  directory_type: 'openldap'
+  disabled: False
+  docu_url: ''
+  group_dn: ''
+  group_scope: 'sub'
+  id: 'default'
+  user_dn: ''
+  user_id_umlauts: 'keep'
+  user_scope: 'sub'
+
+
 # ----------------
 # Monitoring Rules
 # ----------------

--- a/docs/defaults-configuration.rst
+++ b/docs/defaults-configuration.rst
@@ -99,3 +99,242 @@ Create custom administrator account with random password::
         alias: 'Bob Admin'
         password: '{{ lookup("password", "credentials/check_mk/" + checkmk_server__site + "/bob/password length=15") }}'
         roles: [ 'admin' ]
+
+
+.. _checkmk_server__multisite_user_connections:
+
+checkmk_server__multisite_user_connections
+------------------------------------------
+
+List of LDAP user synchronization connection definitions. Multiple connection
+definitions are allowed. Each connection can define the following properties
+via Ansible inventory:
+
+``binddn``
+  Distinguished name used for authenticating against the LDAP server, required.
+
+``bindpw``
+  Password used for authenticating against the LDAP server, required.
+
+``server``
+  LDAP server host name, required.
+
+``group_dn``
+  Base DN for LDAP group queries, required.
+
+``userdn``
+  Base DN for LDAP user queries, required.
+
+``active_plugins``
+  Optional. Configuration dictionary of attribute synchronization plugins. See
+  :ref:`checkmk_server__multisite_ldap_plugins` for more details.
+
+``cache_livetime``
+  Optional. Time in seconds how long to cache LDAP user information. Defaults
+  to: ``300``.
+
+``comment``
+  Optional. Comment about user connection definition.
+
+``connect_timeout``
+  Optional. Connect timeout.
+
+``debug_log``
+  Optional. Enable debug logging for LDAP user synchronization. Allowed values
+  are ``True`` or ``False``. Defaults to: ``False``
+
+``description``
+  Optional. Short description of user connection definition being displayed
+  in the connection list.
+
+``directory_type``
+  Optional. LDAP directory type used to set default user and group attributes.
+  Allowed values are ``openldap``, ``389directoryserver`` or ``ad``. Defaults
+  to: ``openldap``.
+
+``disabled``
+  Optional. Do not enable user connection. Allowed values are ``True`` or
+  ``False``. Defaults to: ``False``
+
+``docu_url``
+  Optional. Documentation URL.
+
+``failover_servers``
+  Optional. List of failover LDAP host names.
+
+``group_filter``
+  Optional. Group search filter (e.g. ``(objectclass=groupOfNames)``). This
+  will overwrite the default set by ``item.directory_type``.
+
+``group_member``
+  Optional. Group member attribute name (e.g. ``member``).
+
+``group_scope``
+  Optional. Group search scope. Allowed values are ``sub`` (search whole
+  subtree below base DN), ``base`` (search only the entry at the base DN) or
+  ``one`` (search all entries one level below the base DN). Defaults to:
+  ``sub``.
+
+``id``
+  Optional. Connection identifier. Defaults to ``default``.
+
+``lower_user_ids``
+  Optional. Set lower case user IDs. Allowed values are ``True`` or ``False``.
+  Defaults to: ``False``
+
+``no_persistent``
+  Optional. Don't use persistent LDAP connections. Allowed values are ``True``
+  or ``False``. Defaults to: ``False``
+
+``port``
+  Optional. TCP port. Defaults to: ``389``
+
+``response_timeout``
+  Optional. Response timeout.
+
+``suffix``
+  Optional. LDAP connection suffix.
+
+``use_ssl``
+  Optional. Encrypt the network connection using SSL. Allowed values are
+  ``True`` or ``False``. Defaults to: ``False``
+
+``user_filter``
+  Optional. User search filter (e.g. ``(objectclass=account)``). This
+  will overwrite the default set by ``item.directory_type``.
+
+``user_filter_group``
+  Optional. Filter users by group.
+
+``user_id``
+  Optional. User ID attribute name (e.g. ``uid``).
+
+``user_id_umlauts``
+  Optional. Translate Umlauts in user IDs (deprecated). Allowed values are
+  ``keep`` or ``replace``. Defaults to ``keep``.
+
+``user_scope``
+  Optional. User search scope. Allowed values are ``sub`` (search whole
+  subtree below base DN), ``base`` (search only the entry at the base DN) or
+  ``one`` (search all entries one level below the base DN). Defaults to:
+  ``sub``.
+
+
+.. _checkmk_server__multisite_ldap_plugins:
+
+LDAP Attribute Synchronization Plugins
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The LDAP user synchronization connector supports various plugins for setting
+WATO user properties based on LDAP attributes and filters. Each plugin is
+a configuration dictionary with the plugin name as key.
+
+``alias``
+  Set user alias based on LDAP attribute.
+
+  ``attr``
+    Optional. LDAP attribute to sync. Defaults to ``cn``.
+
+``auth_expire``
+  Checks wether or not the user auth must be invalidated.
+
+  ``attr``
+    Optional. LDAP attribute to be used as indicator. Defaults to
+    ``krbpasswordexpiration``.
+
+``disable_notifications``
+  Disable notifications based on LDAP attribute.
+
+  ``attr``
+    Optional. LDAP attribute to sync.
+
+``email``
+  Set email address based on LDAP attribute.
+
+  ``attr``
+  Optional. LDAP attribute to sync. Default to ``mail``.
+
+``force_authuser``
+  Set visibility of host/services based on LDAP attribute.
+
+  ``attr``
+    Optional. LDAP attribute to sync.
+
+``force_authuser_webservice``
+  Set visibility of host/services for WebAPI access based on LDAP attribute.
+
+  ``attr``
+    Optional. LDAP attribute to sync.
+
+``groups_to_attributes``
+  Set custom user attributes based on the group memberships in LDAP.
+
+  ``nested``
+    Optional. Handle nested group memberships (Active Directory only at the
+    moment)
+
+  ``other_connections``
+    Optional. List of alternative LDAP connection IDs to sync group membership.
+
+``groups_to_contactgroups``
+  Add the user to contactgroups based on the group memberships in LDAP.
+
+  ``nested``
+    Optional. Handle nested group memberships (Active Directory only at the
+    moment)
+
+  ``other_connections``
+    Optional. List of alternative LDAP connection IDs to sync contactgroup
+    membership.
+
+``groups_to_roles``
+  Set user roles based on distinguished names from LDAP. This is a
+  configuration dictionary with the role name defined in
+  :envvar:`checkmk_server__multisite_roles` as key and a list of group
+  references as value. Each group reference supports the following properties.
+
+  ``group_dn``
+    Group DN used for role assignment.
+
+  ``connection``
+    Optional. Alternative connection ID used for group query.
+
+``pager``
+  Set pager number based on LDAP attribute.
+
+  ``attr``
+    Optional. LDAP attribute to be used as indicator. Defaults to ``mobile``.
+
+``start_url``
+  Set WATO start URL based on LDAP attribute.
+
+  ``attr``
+    Optional. LDAP attribute to sync. Defaults to ``start_url``.
+
+
+.. _checkmk_server__multisite_user_connections_example:
+
+Example
+~~~~~~~
+
+Small example configuration for user authentication via LDAP showing the use
+of some LDAP plugins::
+
+    checkmk_server__multisite_user_connections:
+      - server: 'localhost'
+        binddn: 'cn=admin,dc=example,dc=com'
+        bindpw: 'secret'
+        group_dn: 'ou=groups,dc=example,dc=com'
+        user_dn: 'ou=users,dc=example,dc=com'
+        user_filter: '(objectclass=posixAccount)'
+        active_plugins:
+          alias:
+            attr: 'gecos'
+          groups_to_roles:
+            admin:
+              - group_dn: 'cn=wato-admin,ou=groups,dc=example,dc=com'
+
+This will synchronize all users in from the DN ``ou=users,dc=example,dc=com``
+to WATO, fills the user's alias property with the value from the ``gecos``
+LDAP attribute and assign the admin role to the members of the 'wato-admin'
+group.

--- a/tasks/site.yml
+++ b/tasks/site.yml
@@ -175,7 +175,7 @@
     owner: '{{ checkmk_server__user }}'
     group: '{{ checkmk_server__group }}'
     mode: '{{ "0660"
-              if item | basename | replace(".j2", "") in [ "hosttags.mk", "users.mk" ]
+              if item | basename | replace(".j2", "") in [ "hosttags.mk", "users.mk", "user_connections.mk" ]
               else "0644" }}'
   with_fileglob: [ '../templates/etc/check_mk/multisite.d/wato/*.mk.j2' ]
   notify: [ 'Reload Check_MK configuration' ]

--- a/templates/etc/check_mk/multisite.d/wato/user_connections.mk.j2
+++ b/templates/etc/check_mk/multisite.d/wato/user_connections.mk.j2
@@ -1,0 +1,56 @@
+{% for _conn in checkmk_server__multisite_user_connections|d([]) %}
+{#
+ # Set bind credentials
+ #}
+{%   if ("binddn" in _conn|list) and ("bindpw" in _conn|list) %}
+{%     set _ = _conn.update({'bind': "'" + _conn.binddn + "', '" + _conn.bindpw + "'"}) %}
+{%   endif %}
+{#
+ # Set plugin configuration
+ #}
+{%   for _plugin in _conn.active_plugins|d({}) %}
+{%     if _plugin == "groups_to_roles" %}
+{%       set _role_mappings = {} %}
+{%       for _role in _conn.active_plugins[_plugin]|list %}
+{%         set _filter_list = [] %}
+{%         for _filter in _conn.active_plugins[_plugin][_role] %}
+{%           set _ = _filter_list.append("'" + _filter.group_dn + "', '" + _filter.connection|d("None") + "'") %}
+{%         endfor %}
+{%         set _ = _role_mappings.update({_role: _filter_list }) %}
+{%       endfor %}
+{%       set _ = _conn.active_plugins.update({_plugin: _role_mappings}) %}
+{%     endif %}
+{%   endfor %}
+{#
+ # Strip Ansible-only properties from user definitions
+ #}
+{%   for _prop in checkmk_server__ansible_user_connections_properties|d([]) %}
+{%     if _prop in _conn|list %}
+{%       set _ = _conn.pop(_prop) %}
+{%     endif %}
+{%   endfor %}
+{#
+ # Make sure default arguments are defined
+ #}
+{%   for _key, _value in (checkmk_server__multisite_user_connection_defaults|d({})).iteritems() %}
+{%     if _key not in _conn|list %}
+{%       set _ = _conn.update({_key: _value}) %}
+{%     endif %}
+{%   endfor %}
+{% endfor %}
+# Written by Multisite UserDB
+# encoding: utf-8
+
+{% if checkmk_server__version | version_compare("1.2.8", ">=") %}
+user_connections = \
+{#
+ # Pretty print dictionary, adapt unicode string hinting and construct tuple from quotes
+ #}
+{{ checkmk_server__multisite_user_connections|d([]) | pprint |
+     replace("'None'", "None") |
+     regex_replace("([ :,\[][ \[\{])u'", "\\1'") |
+     regex_replace(": [u]?\"", ": (u") | replace("\",", "),") |
+     regex_replace("\[\"'", "[(u'") | replace("\"]", ")]") |
+     regex_replace("'(comment|description|group_dn|suffix|user_dn|user_filter_group)': '", "'\\1': u'") }}
+{% endif %}
+

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -11,3 +11,7 @@ checkmk_server__site_home: '/opt/omd/sites/{{ checkmk_server__site }}'
 
 # Ansible user properties which are not set in the users.mk
 checkmk_server__ansible_user_properties: [ 'password' ]
+
+# Ansible user_connections properties which are not set in the
+# user_connections.mk
+checkmk_server__ansible_user_connections_properties: [ 'binddn', 'bindpw' ]


### PR DESCRIPTION
This commit will allow you to configure a LDAP server for managing WATO users. For more details about this feature, check the [upstream documentation](https://mathias-kettner.de/checkmk_multisite_ldap_integration.html) (a bit outdated!) and the role documentation.
