### PR TITLE
Generate facts for all sites

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -6,9 +6,9 @@
     state: restarted
 
 - name: Reload Check_MK configuration
-  command: '/omd/sites/{{ checkmk_server__site }}/bin/cmk --reload'
+  command: '{{ checkmk_server__site_base }}/{{ checkmk_server__site }}/bin/cmk --reload'
   environment:
-    OMD_ROOT: '/omd/sites/{{ checkmk_server__site }}'
+    OMD_ROOT: '{{ checkmk_server__site_base }}/{{ checkmk_server__site }}'
 
 - name: Reload apache2
   service:

--- a/tasks/site.yml
+++ b/tasks/site.yml
@@ -16,7 +16,7 @@
 - name: Create Check_MK site
   command: omd create '{{ checkmk_server__site }}'
   args:
-    creates: '/omd/sites/{{ checkmk_server__site }}/etc/omd/site.conf'
+    creates: '{{ checkmk_server__site_base }}/{{ checkmk_server__site }}/etc/omd/site.conf'
 
 - name: Get Check_MK site version
   command: omd version '{{ checkmk_server__site }}'
@@ -121,12 +121,6 @@
     mode: '0644'
   when: checkmk_server__sshkeys|d() and
         "publickey_file" in checkmk_server__sshkeys|d()
-
-- name: Read SSH public key
-  command: 'cat {{ checkmk_server__site_home }}/.ssh/id_rsa.pub'
-  changed_when: False
-  register: checkmk_server_register_ssh_pubkey
-  when: checkmk_server__sshkeys|d()
 
 - name: Generate multisite permission roles definition
   template:

--- a/templates/etc/ansible/facts.d/checkmk_server.fact.j2
+++ b/templates/etc/ansible/facts.d/checkmk_server.fact.j2
@@ -1,3 +1,11 @@
-{
-"ssh_publickey": "{{ checkmk_server_register_ssh_pubkey.stdout }}"
-}
+{% set _site_filter = checkmk_server__site_base + "/*" %}
+{% set _site_facts = {} %}
+{% for _site in _site_filter | fileglob %}
+{%   set _site_name = _site | replace(checkmk_server__site_base + "/", "") %}
+{%   set _site_pubkey = _site + "/.ssh/id_rsa.pub" %}
+{%   set _pubkey = lookup("pipe", "test -f " + _site_pubkey + " && cat " + _site_pubkey + " || true") %}
+{%   if _pubkey %}
+{%     set _ = _site_facts.update({_site_name: {'ssh_publickey': _pubkey}}) %}
+{%   endif %}
+{% endfor %}
+{{ _site_facts | to_nice_json }}

--- a/templates/etc/ansible/facts.d/checkmk_server.fact.j2
+++ b/templates/etc/ansible/facts.d/checkmk_server.fact.j2
@@ -3,7 +3,7 @@
 {% for _site in _site_filter | fileglob %}
 {%   set _site_name = _site | replace(checkmk_server__site_base + "/", "") %}
 {%   set _site_pubkey = _site + "/.ssh/id_rsa.pub" %}
-{%   set _pubkey = lookup("pipe", "test -f " + _site_pubkey + " && cat " + _site_pubkey + " || true") %}
+{%   set _pubkey = lookup("pipe", "sudo test -f " + _site_pubkey + " && sudo cat " + _site_pubkey + " || true") %}
 {%   if _pubkey %}
 {%     set _ = _site_facts.update({_site_name: {'ssh_publickey': _pubkey}}) %}
 {%   endif %}

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,5 +1,8 @@
 ---
 
+# Check_MK site base
+checkmk_server__site_base: '/opt/omd/sites'
+
 # Check_MK site user name (mustn't exist before creating the site)
 checkmk_server__user: '{{ checkmk_server__site }}'
 
@@ -7,7 +10,7 @@ checkmk_server__user: '{{ checkmk_server__site }}'
 checkmk_server__group: '{{ checkmk_server__site }}'
 
 # Check_MK site chroot directory
-checkmk_server__site_home: '/opt/omd/sites/{{ checkmk_server__site }}'
+checkmk_server__site_home: '{{ checkmk_server__site_base }}/{{ checkmk_server__site }}'
 
 # User properties used for user definition in users.mk
 checkmk_server__user_properties: [ 'alias', 'automation_secret', 'connector',


### PR DESCRIPTION
Currently the `checkmk_server` role only allows you to manage one site. However, you may have multiple playbooks for multiple sites or manually manage other sites. If possible also generate facts for other sites, so that the `checkmk_agent` role can relate to them (see debops-contrib/ansible-checkmk_agent#15).
