### PR TITLE
Refactor config file templating

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -124,71 +124,86 @@ checkmk_server__multisite_config_path: 'etc/check_mk/multisite.d'
 #
 # List of dictionaries which will generate the Check_MK multisite
 # configuration in :envvar:`checkmk_server__multisite_config_path`.
-checkmk_server__multisite_config_map: '{{ checkmk_server__wato_host_tags +
-                                          checkmk_server__wato_aux_tags }}'
+checkmk_server__multisite_config_map: '{{ checkmk_server__multisite_cfg_wato_host_tags +
+                                          checkmk_server__multisite_cfg_wato_aux_tags +
+                                          checkmk_server__multisite_cfg_roles }}'
 
 
-# .. envvar:: checkmk_server__wato_host_tags
+# .. envvar:: checkmk_server__multisite_cfg_default_hosttags
 #
-# Define the default upstream ``wato_host_tags`` configuration with
-# additional ``cmk-agent-ssh`` tag to indicate SSH-based Check_MK agents.
-checkmk_server__wato_host_tags:
+# Multisite ``wato_host_tags`` variable definition.
+checkmk_server__multisite_cfg_wato_host_tags:
   - name: 'wato_host_tags'
-    value:
-      - 'agent':
-          'Agent type':
-            - 'cmk-agent':
-                'Check_MK Agent (xinetd)': ['tcp']
-            - 'cmk-agent-ssh':
-                'Check_MK Agent (ssh)': []
-            - 'snmp-only':
-                'SNMP (Networking device, Appliance)': ['snmp']
-            - 'snmp-v1':
-                'Legacy SNMP device (using V1)': ['snmp']
-            - 'snmp-tcp':
-                'Dual: Check_MK Agent + SNMP': ['snmp', 'tcp']
-            - 'ping':
-                'No Agent': []
-      - 'criticality':
-          'Criticality':
-            - 'prod':
-                'Productive system': []
-            - 'critical':
-                'Business critical': []
-            - 'test':
-                'Test system': []
-            - 'offline':
-                'Do not monitor this host': []
-      - 'networking':
-          'Networking Segment':
-            - 'lan':
-                'Local network (low latency)': []
-            - 'wan':
-                'WAN (high latency)': []
-            - 'dmz':
-                'DMZ (low latency, secure access)': []
+    value: '{{ checkmk_server__multisite_default_wato_host_tags }}'
 
 
-# .. envvar:: checkmk_server__wato_aux_tags
+# .. envvar:: checkmk_server__multisite_default_wato_host_tags
 #
-# Define the default upstream ``wato_aux_tags`` configuration.
-checkmk_server__wato_aux_tags:
+# Default upstream host tag configuration with additional ``cmk-agent-ssh`` tag
+# to indicate SSH-based Check_MK agents.
+checkmk_server__multisite_default_wato_host_tags:
+  - agent:
+      'Agent type':
+         - cmk-agent-ssh:
+             'Check_MK Agent (ssh)': []
+         - cmk-agent:
+             'Check_MK Agent (xinetd)': ['tcp']
+         - snmp-only:
+             'SNMP (Networking device, Appliance)': ['snmp']
+         - snmp-v1:
+             'Legacy SNMP device (using V1)': ['snmp']
+         - snmp-tcp:
+             'Dual: Check_MK Agent + SNMP': ['snmp', 'tcp']
+         - ping:
+             'No Agent': []
+  - criticality:
+      'Criticality':
+         - prod:
+             'Productive system': []
+         - critical:
+             'Business critical': []
+         - test:
+             'Test system': []
+         - offline:
+             'Do not monitor this host': []
+  - networking:
+      'Networking Segment':
+         - lan:
+             'Local network (low latency)': []
+         - wan:
+             'WAN (high latency)': []
+         - dmz:
+             'DMZ (low latency, secure access)': []
+
+
+# .. envvar:: checkmk_server__multisite_cfg_wato_aux_tags
+#
+# Multisite ``wato_aux_tags`` variable definition.
+checkmk_server__multisite_cfg_wato_aux_tags:
   - name: 'wato_aux_tags'
-    value:
-      - 'snmp': 'monitor via SNMP'
-      - 'tcp': 'monitor via Check_MK Agent'
+    value: '{{ checkmk_server__multisite_default_wato_aux_tags }}'
 
 
-# .. envvar:: checkmk_server__multisite_roles
+# .. envvar:: checkmk_server__multisite_default_wato_aux_tags
 #
-# Multisite permission roles to be configured
-checkmk_server__multisite_roles: '{{ checkmk_server__default_roles }}'
+# Default upstream auxiliary tags configuration.
+checkmk_server__multisite_default_wato_aux_tags:
+  - snmp: 'monitor via SNMP'
+  - tcp: 'monitor via Check_MK Agent'
 
 
-# .. envvar:: checkmk_server__default_roles
+# .. envvar:: checkmk_server__multisite_cfg_roles
 #
-# Default upstream multisite permission roles
-checkmk_server__default_roles:
+# Multisite user ``roles`` definition.
+checkmk_server__multisite_cfg_roles:
+  - name: 'roles'
+    value: '{{ checkmk_server__multisite_default_roles }}'
+
+
+# .. envvar:: checkmk_server__multisite_default_roles
+#
+# Default upstream user roles configuration.
+checkmk_server__multisite_default_roles:
   admin:
     alias: 'Administrator'
     builtin: True

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -134,8 +134,6 @@ checkmk_server__multisite_config_map: '{{ checkmk_server__wato_host_tags +
 # additional ``cmk-agent-ssh`` tag to indicate SSH-based Check_MK agents.
 checkmk_server__wato_host_tags:
   - name: 'wato_host_tags'
-    filename: 'hosttags.mk'
-    template: 'nested_tuplelist_list'
     value:
       - 'agent':
           'Agent type':
@@ -169,19 +167,16 @@ checkmk_server__wato_host_tags:
                 'WAN (high latency)': []
             - 'dmz':
                 'DMZ (low latency, secure access)': []
-    wato: True
+
 
 # .. envvar:: checkmk_server__wato_aux_tags
 #
 # Define the default upstream ``wato_aux_tags`` configuration.
 checkmk_server__wato_aux_tags:
   - name: 'wato_aux_tags'
-    filename: 'hosttags.mk'
-    template: 'tuple_list'
     value:
       - 'snmp': 'monitor via SNMP'
       - 'tcp': 'monitor via Check_MK Agent'
-    wato: True
 
 
 # .. envvar:: checkmk_server__multisite_roles
@@ -298,11 +293,8 @@ checkmk_server__contact_defaults:
 # Default upstream contactgroups
 checkmk_server__default_contactgroups:
   - name: 'define_contactgroups'
-    filename: 'groups.mk'
-    template: 'dict_element'
     value:
       all: 'Everybody'
-    wato: True
 
 
 # .. envvar:: checkmk_server__datasource_programs
@@ -310,12 +302,9 @@ checkmk_server__default_contactgroups:
 # Define additional ``datasource_programs`` for agent access via SSH.
 checkmk_server__datasource_programs:
   - name: 'datasource_programs'
-    filename: 'rules.mk'
-    template: 'rule'
     value: 'ssh -o BatchMode=yes -o StrictHostKeyChecking=no -o ConnectTimeout=10s -l root <IP> /usr/bin/check_mk_agent'
     tags: [ 'cmk-agent-ssh' ]
     description: 'Check_MK Agent via SSH'
-    wato: True
 
 
 # .. envvar:: checkmk_server__software_inventory_rules:
@@ -324,16 +313,10 @@ checkmk_server__datasource_programs:
 # enabled/disabled by setting :envvar:`checkmk_server__software_inventory`.
 checkmk_server__rules_software_inventory:
   - name: 'inventory_check_interval'
-    filename: 'global.mk'
-    wato: True
-    template: 'key_value'
     value: 1440
     rule_state: '{{ "present" if checkmk_server__software_inventory|d() | bool
                     else "absent" }}'
   - name: 'cmk_inv'
-    filename: 'rules.mk'
-    wato: True
-    template: 'active_check'
     filter: 'ALL_HOSTS'
     comment: 'Enable collection of hardware/software information'
     rule_state: '{{ "present" if checkmk_server__software_inventory|d() | bool

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -280,10 +280,10 @@ checkmk_server__site_config_path: 'etc/check_mk/conf.d'
 #
 # List of configuration dictionaries which will generate the Check_MK
 # monitoring definitions.
-checkmk_server__site_config_map: '{{ checkmk_server__default_contactgroups +
-                                     checkmk_server__datasource_programs +
-                                     checkmk_server__if_inventory_uses_description +
-                                     checkmk_server__rules_software_inventory }}'
+checkmk_server__site_config_map: '{{ checkmk_server__site_cfg_contactgroups +
+                                     checkmk_server__site_cfg_datasource_programs +
+                                     checkmk_server__site_cfg_netif_description +
+                                     checkmk_server__site_cfg_software_inventory }}'
 
 
 # .. envvar:: checkmk_server__contact_defaults
@@ -292,7 +292,7 @@ checkmk_server__site_config_map: '{{ checkmk_server__default_contactgroups +
 # see `checkmk_server__contact_properties` defined in :file:`vars/main.yml`.
 # They are described under :envvar:`checkmk_server__multisite_users`.
 checkmk_server__contact_defaults:
-  contactgroups: []
+  contactgroups: [ 'all' ]
   disable_notifications: False
   email: ''
   host_notification_options: 'durfs'
@@ -303,30 +303,30 @@ checkmk_server__contact_defaults:
   service_notification_options: 'wucrfs'
 
 
-# .. envvar:: checkmk_server__default_contactgroups
+# .. envvar:: checkmk_server__site_cfg_contactgroups
 #
-# Default upstream contactgroups
-checkmk_server__default_contactgroups:
+# Define default contact group for all contacts.
+checkmk_server__site_cfg_contactgroups:
   - name: 'define_contactgroups'
     value:
       all: 'Everybody'
 
 
-# .. envvar:: checkmk_server__datasource_programs
+# .. envvar:: checkmk_server__site_cfg_datasource_programs
 #
 # Define additional ``datasource_programs`` for agent access via SSH.
-checkmk_server__datasource_programs:
+checkmk_server__site_cfg_datasource_programs:
   - name: 'datasource_programs'
     value: 'ssh -o BatchMode=yes -o StrictHostKeyChecking=no -o ConnectTimeout=10s -l root <IP> /usr/bin/check_mk_agent'
     tags: [ 'cmk-agent-ssh' ]
     description: 'Check_MK Agent via SSH'
 
 
-# .. envvar:: checkmk_server__software_inventory_rules:
+# .. envvar:: checkmk_server__site_cfg_software_inventory:
 #
 # Check_MK rules for enabling software inventory check. This check can be
 # enabled/disabled by setting :envvar:`checkmk_server__software_inventory`.
-checkmk_server__rules_software_inventory:
+checkmk_server__site_cfg_software_inventory:
   - name: 'inventory_check_interval'
     value: 1440
     rule_state: '{{ "present" if checkmk_server__software_inventory|d() | bool
@@ -338,11 +338,11 @@ checkmk_server__rules_software_inventory:
                     else "absent" }}'
 
 
-# .. envvar:: checkmk_server__if_inventory_uses_description
+# .. envvar:: checkmk_server__site_cfg_netif_description
 #
 # Set interface name instead of index for network interface check via
 # ``if_inventory_uses_description``.
-checkmk_server__if_inventory_uses_description:
+checkmk_server__site_cfg_netif_description:
   - name: 'if_inventory_uses_description'
     filename: 'networking.mk'
     template: 'key_value'

--- a/docs/defaults-configuration.rst
+++ b/docs/defaults-configuration.rst
@@ -115,7 +115,7 @@ properties can be set via Ansible inventory:
 
 ``roles``
   Optional. List of permission roles defined in
-  :envvar:`checkmk_server__multisite_roles`. Defaults to ``[ 'user' ]``.
+  :envvar:`checkmk_server__multisite_cfg_roles`. Defaults to ``[ 'user' ]``.
 
 ``service_notification_options``
   Optional. Service events which should be notified. String combined of the
@@ -336,7 +336,7 @@ a configuration dictionary with the plugin name as key.
 ``groups_to_roles``
   Set user roles based on distinguished names from LDAP. This is a
   configuration dictionary with the role name defined in
-  :envvar:`checkmk_server__multisite_roles` as key and a list of group
+  :envvar:`checkmk_server__multisite_cfg_roles` as key and a list of group
   references as value. Each group reference supports the following properties.
 
   ``group_dn``

--- a/tasks/site.yml
+++ b/tasks/site.yml
@@ -197,7 +197,7 @@
     group: '{{ checkmk_server__group }}'
     mode: '0644'
   with_items: '{{ checkmk_server__multisite_config_map }}'
-  when: not item['wato']
+  when: not item['wato']|d(True)
   notify: [ 'Reload Check_MK configuration' ]
   tags: [ 'role::checkmk_server:rules', 'role::checkmk_server:multisite' ]
 
@@ -222,6 +222,6 @@
     group: '{{ checkmk_server__group }}'
     mode: '0644'
   with_items: '{{ checkmk_server__site_config_map }}'
-  when: not item['wato']
+  when: not item['wato']|d(True)
   notify: [ 'Reload Check_MK configuration' ]
   tags: [ 'role::checkmk_server:rules' ]

--- a/tasks/site.yml
+++ b/tasks/site.yml
@@ -128,15 +128,6 @@
   register: checkmk_server_register_ssh_pubkey
   when: checkmk_server__sshkeys|d()
 
-- name: Generate multisite permission roles definition
-  template:
-    src: 'etc/check_mk/multisite.d/wato/roles.mk.j2'
-    dest: '{{ checkmk_server__site_home }}/{{ checkmk_server__multisite_config_path }}/wato/roles.mk'
-    owner: '{{ checkmk_server__user }}'
-    group: '{{ checkmk_server__group }}'
-    mode: '0644'
-  tags: [ 'role::checkmk_server:multisite' ]
-
 - name: Wait for the site to be started
   wait_for:
     path: '{{ checkmk_server__site_home }}/{{ checkmk_server__multisite_config_path }}/wato/users.mk'

--- a/templates/etc/check_mk/conf.d/custom.mk.j2
+++ b/templates/etc/check_mk/conf.d/custom.mk.j2
@@ -1,5 +1,4 @@
-# {{ ansible_managed }}
 {% import 'checkmk_config.j2' as macros with context %}
+# {{ ansible_managed }}
 # encoding: utf-8
-
-{{ macros.checkmk_config(item['filename'], False, checkmk_server__site_config_map|d([])|list) }}
+{{ macros.tmpl_set_config(item['filename'], False, checkmk_server__site_config_map|d([])|list) }}

--- a/templates/etc/check_mk/conf.d/wato/global.mk.j2
+++ b/templates/etc/check_mk/conf.d/wato/global.mk.j2
@@ -1,12 +1,12 @@
-# {{ ansible_managed }}
 {#
-
-This file provides the default global configuration as shipped with upstream
-Check_MK. It can be extended by custom rule definitions in the Ansible
-inventory.
-
-#}
+ #
+ # This file provides the default global configuration as shipped with upstream
+ # Check_MK. It can be extended by custom rule definitions in the Ansible
+ # inventory.
+ #
+ #}
 {% import 'checkmk_config.j2' as macros with context %}
+# {{ ansible_managed }}
 # encoding: utf-8
 
 use_new_descriptions_for = ['df',
@@ -42,5 +42,4 @@ use_new_descriptions_for = ['df',
  'innovaphone_temp',
  'enterasys_temp']
 enable_rulebased_notifications = True
-
-{{ macros.checkmk_config('global.mk', True, checkmk_server__site_config_map|d([])) }}
+{{ macros.tmpl_set_config('global.mk', True, checkmk_server__site_config_map|d([])) }}

--- a/templates/etc/check_mk/conf.d/wato/groups.mk.j2
+++ b/templates/etc/check_mk/conf.d/wato/groups.mk.j2
@@ -1,4 +1,4 @@
 {% import 'checkmk_config.j2' as macros with context %}
 # {{ ansible_managed }}
 # encoding: utf-8
-{{ macros.checkmk_config('groups.mk', True, checkmk_server__site_config_map|d([])) }}
+{{ macros.tmpl_set_config('groups.mk', True, checkmk_server__site_config_map|d([])) }}

--- a/templates/etc/check_mk/conf.d/wato/rules.mk.j2
+++ b/templates/etc/check_mk/conf.d/wato/rules.mk.j2
@@ -1,12 +1,12 @@
-# {{ ansible_managed }}
 {#
-
-This file provides the default rules configuration as shipped with upstream
-Check_MK. It can be extended by custom rule definitions in the Ansible
-inventory.
-
-#}
+ #
+ # This file provides the default rules configuration as shipped with upstream
+ # Check_MK. It can be extended by custom rule definitions in the Ansible
+ # inventory.
+ #
+ #}
 {% import 'checkmk_config.j2' as macros with context %}
+# {{ ansible_managed }}
 # encoding: utf-8
 
 
@@ -39,4 +39,4 @@ only_hosts = [
   ( ['!offline', ], ALL_HOSTS, {'description': u'Do not monitor hosts with the tag "offline"'} ),
 ] + only_hosts
 
-{{ macros.checkmk_config('rules.mk', True, checkmk_server__site_config_map|d([])) }}
+{{ macros.tmpl_set_config('rules.mk', True, checkmk_server__site_config_map|d([])) }}

--- a/templates/etc/check_mk/multisite.d/custom.mk.j2
+++ b/templates/etc/check_mk/multisite.d/custom.mk.j2
@@ -1,5 +1,4 @@
-# {{ ansible_managed }}
 {% import 'checkmk_config.j2' as macros with context %}
+# {{ ansible_managed }}
 # encoding: utf-8
-
-{{ macros.checkmk_config(item['filename'], False, checkmk_server__multisite_config_map|d([])|list) }}
+{{ macros.tmpl_set_config(item['filename'], False, checkmk_server__multisite_config_map|d([])|list) }}

--- a/templates/etc/check_mk/multisite.d/wato/hosttags.mk.j2
+++ b/templates/etc/check_mk/multisite.d/wato/hosttags.mk.j2
@@ -1,5 +1,4 @@
-# {{ ansible_managed }}
 {% import 'checkmk_config.j2' as macros with context %}
+# {{ ansible_managed }}
 # encoding: utf-8
-
-{{ macros.checkmk_config('hosttags.mk', True, checkmk_server__multisite_config_map|d([])) }}
+{{ macros.tmpl_set_config('hosttags.mk', True, checkmk_server__multisite_config_map|d([])) }}

--- a/templates/etc/check_mk/multisite.d/wato/roles.mk.j2
+++ b/templates/etc/check_mk/multisite.d/wato/roles.mk.j2
@@ -1,6 +1,4 @@
+{% import 'checkmk_config.j2' as macros with context %}
 # {{ ansible_managed }}
 # encoding: utf-8
-
-roles.update(
-{ {% for role, params in checkmk_server__multisite_roles|dictsort %}'{{ role }}': {{ params | replace("u'", "'") }}{% if not loop.last %},
-  {% endif %}{% endfor %} })
+{{ macros.tmpl_set_config('roles.mk', True, checkmk_server__multisite_config_map|d([])) }}

--- a/templates/macros/checkmk_config.j2
+++ b/templates/macros/checkmk_config.j2
@@ -1,108 +1,150 @@
-{% macro checkmk_config(_filename, _wato, _config_map) %}
-{% if _config_map|d([]) | list %}
-{%   for _entry in _config_map %}
-{%     if (_entry.filename|d("") == _filename) and (_entry.wato|d(True) == _wato|bool) %}
+{#
+ # The tmpl_set_config() macro will iterate through the given list of config
+ # dictionaries and generate the Check_MK configuration values if they belong
+ # to the given file name.
+ #}
+
+{% macro tmpl_set_config(_tmpl_file, _wato, _config) %}
+{%   for _entry in _config %}
+{%     if 'filename' in _entry %}
+{%       set _cfg_file = _entry.filename %}
+{%     else %}
+{%       set _cfg_file = checkmk_server__variable_map[_entry.name|d("undefined name")].filename %}
+{%     endif %}
+{%     if (_cfg_file == _tmpl_file) and (_entry.wato|d(True) == _wato|bool) %}
 {%       set _state = 'present' %}
 {%       if 'rule_state' in _entry %}
 {%         set _state = _entry.rule_state %}
 {%       endif %}
 {%       if _state == 'present' %}
-{%         set _template = _entry.template|d("custom") %}
-{%         if _template == 'key_value' %}
-{{ key_value(_entry.name, _entry.value) }}
-{%         elif _template == 'dict_element' %}
-{{ dict_element(_entry.name, _entry.value) }}
-{%         elif _template == 'tuple_list' %}
-{{ tuple_list(_entry.name, _entry.value) }}
-{%         elif _template == 'rule' %}
-{{ rule(_entry.name, _entry.value, _entry.tags, _entry.description) }}
-{%         elif _template == 'active_check' %}
-{{ active_check(_entry.name, _entry.filter, _entry.comment) }}
-{%         elif _template == 'nested_tuplelist_list' %}
-{{ nested_tuplelist_list(_entry.name, _entry.value) }}
-{%         elif _template == 'custom' %}
-{{ custom(_entry.content) }}
-{%         endif %}
-{%       endif %}
+{{         tmpl_var_define(_entry) }}{%
+         endif %}
 {%     endif %}
 {%   endfor %}
-{% endif %}
 {% endmacro %}
 
 
 {#
- # The key_value() macro will generate simple key/value variable definitions
+ # The tpl_var_define() macro will call the appropriate variable formatting
+ # macro for the given configuration entry.
  #}
 
-{% macro key_value(name, value) %}
-
-{{ name }} = {{ value }}
+{% macro tmpl_var_define(_cfg_entry) %}
+{%   if 'template' in _cfg_entry %}
+{%     set _template = _cfg_entry.template %}
+{%   elif checkmk_server__variable_map[_cfg_entry.name|d("undefined name")].template|d() %}
+{%     set _template = checkmk_server__variable_map[_cfg_entry.name].template %}
+{%   else %}
+{%     set _template = 'custom' %}
+{%   endif %}
+{%   if _template == 'key_value' %}
+{{     tmpl_var__key_value(_cfg_entry.name, _cfg_entry.value|d("")) }}{%
+     elif _template == 'dict_update' %}
+{{     tmpl_var__dict_update(_cfg_entry.name, _cfg_entry.value|d("")) }}{%
+     elif _template == 'dict_update_legacy' %}
+{{     tmpl_var__dict_update_legacy(_cfg_entry.name, _cfg_entry.value|d("")) }}{%
+     elif _template == 'tuple_list' %}
+{{     tmpl_var__tuple_list(_cfg_entry.name, _cfg_entry.value|d("")) }}{%
+     elif _template == 'nested_tuple_list' %}
+{{     tmpl_var__nested_tuple_list(_cfg_entry.name, _cfg_entry.value|d("")) }}{%
+     elif _template == 'rule' %}
+{{     tmpl_var__rule(_cfg_entry.name, _cfg_entry.value|d(""), _cfg_entry.tags|d([]), _cfg_entry.description|d("")) }}{%
+     elif _template == 'active_check' %}
+{{     tmpl_var__active_check(_cfg_entry.name, _cfg_entry.filter, _cfg_entry.comment) }}{%
+     elif _template == 'custom' %}
+{{     tmpl_var__custom(_cfg_entry.content|d("")) }}{%
+     endif %}
 {% endmacro %}
 
 
 {#
- # The dict_element() macro will generate configuration statement for updating
- # a Python dictionary. Likely to avoid collision with older variables, it
- # includes a check for the object type and conditional re-initialization.
+ # The tmpl_var__key_value() macro will generate simple key/value variable
+ # definitions.
  #}
 
-{% macro dict_element(name, value) %}
+{% macro tmpl_var__key_value(_name, _value) %}
 
-if type({{ name }}) != dict:
-    {{ name }} = {}
-{{ name }}.update({{ value | pprint }})
+{{ _name }} = {{ _value }}
 {% endmacro %}
 
 
 {#
- # The tuple_list() macro will generate a variable definition with
+ # The tmpl_var__dict_update_legacy() macro will generate configuration
+ # statement for updating a Python dictionary. Likely to avoid collision
+ # with older variables it includes a check for the object type and conditional
+ # re-initialization.
+ #}
+
+{% macro tmpl_var__dict_update_legacy(_name, _value) %}
+
+if type({{ _name }}) != dict:
+    {{ _name }} = {}
+{{ _name }}.update({{ _value | pprint }})
+{% endmacro %}
+
+
+{#
+ # The tmpl_var__dict_update() macro will generate configuration statement
+ # for updating a Python dictionary.
+ #}
+
+{% macro tmpl_var__dict_update(_name, _value) %}
+
+{{ _name }}.update(
+{{ _value | pprint }})
+{% endmacro %}
+
+
+{#
+ # The tmpl_var__tuple_list() macro will generate a variable definition with
  # list of tuples "[('key', u'value')]" which must be given as a list
  # of key/value pairs.
  #}
 
-{% macro tuple_list(name, elements) %}
+{% macro tmpl_var__tuple_list(_name, _element_list) %}
 
-{{ name }} += \
-[{% for e in elements %}('{{ e.keys()[0] }}', u'{{ e.values()[0] }}'){% if not loop.last %}, {% endif %}{% endfor %}]
+{{ _name }} += \
+[{% for _item in _element_list %}('{{ _item.keys()[0] }}', u'{{ _item.values()[0] }}'){% if not loop.last %}, {% endif %}{% endfor %}]
 {% endmacro %}
 
 
 {#
- # The rule() macro will generate a (yet) very simplified variable definition
- # for a monitoring rule.
+ # The tmpl_var__rule() macro will generate a (yet) very simplified variable
+ # definition for a monitoring rule.
  #}
-{% macro rule(name, value, tags, desc) %}
+{% macro tmpl_var__rule(_name, _value, _tags, _desc) %}
 
-{{ name }} = [
-  ( '{{ value }}', ['{{ tags | join("', '") }}', ], ALL_HOSTS, {'description': u'{{ desc }}'} ),
-] + {{ name }}
+{{ _name }} = [
+  ( '{{ _value }}', ['{{ _tags | join("', '") }}', ], ALL_HOSTS, {'description': u'{{ _desc }}'} ),
+] + {{ _name }}
 {% endmacro %}
 
 
 {#
- # The active_check() macro will generate the necessary active_checks variable
- # definition required to define a regular Nagios active check.
+ # The tmpl_var__active_check() macro will generate the necessary
+ # 'active_checks' dictionary entries required to define a regular
+ # Nagios active check.
  #}
-{% macro active_check(name, filter, comment) %}
+{% macro tmpl_var__active_check(_name, _filter, _comment) %}
 
-active_checks.setdefault('{{ name }}', [])
+active_checks.setdefault('{{ _name }}', [])
 
-active_checks['{{ name }}'] = [
-  ( None, [], {{ filter }}, {'comment': u'{{ comment }}' } ),
+active_checks['{{ _name }}'] = [
+  ( None, [], {{ _filter }}, {'comment': u'{{ _comment }}' } ),
 ]
 {% endmacro %}
 
 
 {#
- # The nested_tuplelist_list() macro will generate a variable definition with
- # a list of 3-element tuples, where the last element can be a list of
- # 3-element tuples.
+ # The tmpl_var__nested_tuple_list() macro will generate a variable
+ # definition with a list of 3-element tuples, where the last element can
+ # be a list of 3-element tuples.
  #}
 
-{% macro nested_tuplelist_list(name, elements) %}
+{% macro tmpl_var__nested_tuple_list(_name, _elements) %}
 
-{{ name }} += \
-[{% for e in elements %}('{{ e.keys()[0] }}',
+{{ _name }} += \
+[{% for e in _elements %}('{{ e.keys()[0] }}',
   u'{{ e.values()[0].keys()[0] }}',
   [{% for i in e.values()[0].values()[0] %}('{{ i.keys()[0] }}', u'{{ i.values()[0].keys()[0] }}', [{% for j in i.values()[0].values()[0] %}'{{ j }}'{% if not loop.last %}, {% endif %}{% endfor %}]){% if not loop.last %},
    {% endif %}{% endfor %}]){% if not loop.last %},
@@ -111,10 +153,10 @@ active_checks['{{ name }}'] = [
 
 
 {#
- # The custom() macro will simply print the given content.
+ # The tmpl_var__custom() macro will simply print the given content.
  #}
 
-{% macro custom(content) %}
+{% macro tmpl_var__custom(_content) %}
 
-{{ content }}
+{{ _content }}
 {% endmacro %}

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -36,7 +36,7 @@ checkmk_server__confd_variable_map:
     template: 'dict_update_legacy'
   inventory_check_interval:
     filename: 'global.mk'
-    template: 'key-value'
+    template: 'key_value'
 
 # Configuration varaible definitions for Check_MK multisite definitions
 checkmk_server__multisite_variable_map:

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -19,6 +19,40 @@ checkmk_server__contact_properties: [ 'alias', 'contactgroup',
   'notification_method', 'notification_period', 'notifications_enabled',
   'pager', 'service_notifications_options' ]
 
+# Mapping of variable names to files and templates
+checkmk_server__variable_map: '{{ checkmk_server__confd_variable_map |
+  combine(checkmk_server__multisite_variable_map, recursive=True) }}'
+
+# Configuration variable definitions for Check_MK conf.d definitions
+checkmk_server__confd_variable_map:
+  cmk_inv:
+    filename: 'rules.mk'
+    template: 'active_check'
+  datasource_programs:
+    filename: 'rules.mk'
+    template: 'rule'
+  define_contactgroups:
+    filename: 'groups.mk'
+    template: 'dict_update_legacy'
+  inventory_check_interval:
+    filename: 'global.mk'
+    template: 'key-value'
+
+# Configuration varaible definitions for Check_MK multisite definitions
+checkmk_server__multisite_variable_map:
+  roles:
+    filename: 'roles.mk'
+    template: 'dict_update'
+  wato_aux_tags:
+    filename: 'hosttags.mk'
+    template: 'tuple_list'
+  wato_host_tags:
+    filename: 'hosttags.mk'
+    template: 'nested_tuple_list'
+  wato_use_git:
+    filename: 'global.mk'
+    template: 'key_value'
+
 # Ansible user_connections properties which are not set in the
 # user_connections.mk
 checkmk_server__ansible_user_connections_properties: [ 'binddn', 'bindpw' ]


### PR DESCRIPTION
First try to clean up the Check_MK configuration file templates, make the configuration templating easier to use and harmonize jinja2 code style. No functional change.
