### PR TITLE
Extend rule macro to support more use cases

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -281,6 +281,7 @@ checkmk_server__site_config_path: 'etc/check_mk/conf.d'
 # List of configuration dictionaries which will generate the Check_MK
 # monitoring definitions.
 checkmk_server__site_config_map: '{{ checkmk_server__site_cfg_contactgroups +
+                                     checkmk_server__site_cfg_hostgroups +
                                      checkmk_server__site_cfg_datasource_programs +
                                      checkmk_server__site_cfg_netif_description +
                                      checkmk_server__site_cfg_software_inventory }}'
@@ -310,6 +311,14 @@ checkmk_server__site_cfg_contactgroups:
   - name: 'define_contactgroups'
     value:
       all: 'Everybody'
+
+
+# .. envvar:: checkmk_server__site_cfg_hostgroups
+#
+# Define host groups.
+checkmk_server__site_cfg_hostgroups:
+  - name: 'define_hostgroups'
+    value: {}
 
 
 # .. envvar:: checkmk_server__site_cfg_datasource_programs

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -281,6 +281,7 @@ checkmk_server__site_config_path: 'etc/check_mk/conf.d'
 # List of configuration dictionaries which will generate the Check_MK
 # monitoring definitions.
 checkmk_server__site_config_map: '{{ checkmk_server__site_cfg_contactgroups +
+                                     checkmk_server__site_cfg_rules +
                                      checkmk_server__site_cfg_hostgroups +
                                      checkmk_server__site_cfg_servicegroups +
                                      checkmk_server__site_cfg_datasource_programs +
@@ -312,6 +313,24 @@ checkmk_server__site_cfg_contactgroups:
   - name: 'define_contactgroups'
     value:
       all: 'Everybody'
+
+
+# .. envvar:: checkmk_server__site_cfg_rules
+#
+# Define Check_MK monitoring rules.
+checkmk_server__site_cfg_rules: '{{ checkmk_server__site_upstream_rules }}'
+
+
+# .. envvar:: checkmk_server__site_upstream_rules
+#
+# Default upstream rule definitions
+checkmk_server__site_upstream_rules:
+  - name: 'bulkwalk_hosts'
+    tags: [ 'snmp', '!snmp-v1' ]
+    description: 'Hosts with the tag "snmp-v1" must not use bulkwalk'
+  - name: 'host_contactgroups'
+    value: 'all'
+    description: 'Put all hosts into the contact group "all"'
 
 
 # .. envvar:: checkmk_server__site_cfg_hostgroups

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -282,6 +282,7 @@ checkmk_server__site_config_path: 'etc/check_mk/conf.d'
 # monitoring definitions.
 checkmk_server__site_config_map: '{{ checkmk_server__site_cfg_contactgroups +
                                      checkmk_server__site_cfg_hostgroups +
+                                     checkmk_server__site_cfg_servicegroups +
                                      checkmk_server__site_cfg_datasource_programs +
                                      checkmk_server__site_cfg_netif_description +
                                      checkmk_server__site_cfg_software_inventory }}'
@@ -318,6 +319,14 @@ checkmk_server__site_cfg_contactgroups:
 # Define host groups.
 checkmk_server__site_cfg_hostgroups:
   - name: 'define_hostgroups'
+    value: {}
+
+
+# .. envvar:: checkmk_server__site_cfg_servicegroups
+#
+# Define service groups.
+checkmk_server__site_cfg_servicegroups:
+  - name: 'define_servicegroups'
     value: {}
 
 

--- a/templates/etc/check_mk/conf.d/wato/rules.mk.j2
+++ b/templates/etc/check_mk/conf.d/wato/rules.mk.j2
@@ -10,10 +10,6 @@
 # encoding: utf-8
 
 
-host_contactgroups = [
-  ( 'all', [], ALL_HOSTS, {'description': u'Put all hosts into the contact group "all"'} ),
-] + host_contactgroups
-
 
 extra_service_conf.setdefault('check_interval', [])
 
@@ -25,11 +21,6 @@ extra_service_conf['check_interval'] = [
 ping_levels = [
   ( {'loss': (80.0, 100.0), 'packets': 6, 'timeout': 20, 'rta': (1500.0, 3000.0)}, ['wan', ], ALL_HOSTS, {'description': u'Allow longer round trip times when pinging WAN hosts'} ),
 ] + ping_levels
-
-
-bulkwalk_hosts = [
-  ( ['snmp', '!snmp-v1', ], ALL_HOSTS, {'description': u'Hosts with the tag "snmp-v1" must not use bulkwalk'} ),
-] + bulkwalk_hosts
 
 
 if only_hosts == None:

--- a/templates/macros/checkmk_config.j2
+++ b/templates/macros/checkmk_config.j2
@@ -37,6 +37,22 @@
 {%   else %}
 {%     set _template = 'custom' %}
 {%   endif %}
+{%   if 'hosts' in _cfg_entry %}
+{#
+ #     Host list entries mustn't be formatted as unicode strings
+ #}
+{%     if (_cfg_entry.hosts is iterable) and (_cfg_entry.hosts | length > 0) %}
+{%       set _hosts = "['" + _cfg_entry.hosts | join("', '") + "']" %}
+{%     endif %}
+{%   endif %}
+{%   if 'tags' in _cfg_entry %}
+{#
+ #     Tags are formatted as a list with a trailing comma
+ #}
+{%     set _tags = "['" + _cfg_entry.tags | join("', '") + "', ]" %}
+{%   else %}
+{%     set _tags = "[]" %}
+{%   endif %}
 {%   if _template == 'key_value' %}
 {{     tmpl_var__key_value(_cfg_entry.name, _cfg_entry.value|d("")) }}{%
      elif _template == 'dict_update' %}
@@ -55,7 +71,7 @@
 {%       endif %}
 {%     endfor %}
 
-{{     tmpl_var__rule(_cfg_entry.name, _cfg_entry.value|d(""), _cfg_entry.tags|d([]), _cfg_entry.hosts|d("ALL_HOSTS"), _rule_kwargs) }}{%
+{{     tmpl_var__rule(_cfg_entry.name, _cfg_entry.value|d(""), _tags, _hosts|d("ALL_HOSTS"), _cfg_entry.services|d([]), _rule_kwargs) }}{%
      elif _template == 'active_check' %}
 {{     tmpl_var__active_check(_cfg_entry.name, _cfg_entry.filter, _cfg_entry.comment) }}{%
      elif _template == 'custom' %}
@@ -118,21 +134,23 @@ if type({{ _name }}) != dict:
 {#
  # The tmpl_var__rule() macro will generate a Check_MK rule variable entry.
  #
- # If the _value argument is an empty string, simply omit this item.
+ # Arguments:
+ #   _name: Check_MK variable name (string), required
+ #   _value: Rule name (string), will be omitted if empty
+ #   _tags: Preformatted list of Check_MK tags
+ #   _hosts: Preformatted list of Check_MK host names
+ #   _services: List of service patterns which will be formatted as unicode
+ #              list elements, will be omitted if empty
+ #   _kwargs: Additional rule properties (dictionary)
  #
  # The regex_replace() filter will make sure that the dictionary keys are not
  # serialized as unicode strings.
  #}
 
-{% macro tmpl_var__rule(_name, _value, _tags, _hosts, _kwargs) %}
-{% if _tags %}
-{%   set _formatted_tags = "['" + (_tags | join("', '")) + "', ]" %}
-{% else %}
-{%   set _formatted_tags = "[]" %}
-{% endif %}
+{% macro tmpl_var__rule(_name, _value, _tags, _hosts, _services, _kwargs) %}
 
 {{ _name }} = [
-  ( {{ "'" + _value + "', " if _value | length > 0 else "" }}{{ _formatted_tags }}, {{ _hosts }}, {{ _kwargs | pprint | replace("\n", "") | regex_replace("(, |{)u'", "\\1'") }} ),
+  ( {{ "'" + _value + "', " if _value | length > 0 else "" }}{{ _tags }}, {{ _hosts }}, {{ _services | pprint + ", " if _services | length > 0 else "" }}{{ _kwargs | pprint | replace("\n", "") | regex_replace("(, |{)u'", "\\1'") }} ),
 ] + {{ _name }}
 {% endmacro %}
 

--- a/templates/macros/checkmk_config.j2
+++ b/templates/macros/checkmk_config.j2
@@ -48,7 +48,14 @@
      elif _template == 'nested_tuple_list' %}
 {{     tmpl_var__nested_tuple_list(_cfg_entry.name, _cfg_entry.value|d("")) }}{%
      elif _template == 'rule' %}
-{{     tmpl_var__rule(_cfg_entry.name, _cfg_entry.value|d(""), _cfg_entry.tags|d([]), _cfg_entry.description|d("")) }}{%
+{%     set _rule_kwargs = {} %}
+{%     for _arg in checkmk_server__site_rule_kwargs %}
+{%       if _arg in _cfg_entry %}
+{%         set _ = _rule_kwargs.update({_arg: _cfg_entry[_arg]}) %}
+{%       endif %}
+{%     endfor %}
+
+{{     tmpl_var__rule(_cfg_entry.name, _cfg_entry.value|d(""), _cfg_entry.tags|d([]), _cfg_entry.hosts|d("ALL_HOSTS"), _rule_kwargs) }}{%
      elif _template == 'active_check' %}
 {{     tmpl_var__active_check(_cfg_entry.name, _cfg_entry.filter, _cfg_entry.comment) }}{%
      elif _template == 'custom' %}
@@ -109,13 +116,23 @@ if type({{ _name }}) != dict:
 
 
 {#
- # The tmpl_var__rule() macro will generate a (yet) very simplified variable
- # definition for a monitoring rule.
+ # The tmpl_var__rule() macro will generate a Check_MK rule variable entry.
+ #
+ # If the _value argument is an empty string, simply omit this item.
+ #
+ # The regex_replace() filter will make sure that the dictionary keys are not
+ # serialized as unicode strings.
  #}
-{% macro tmpl_var__rule(_name, _value, _tags, _desc) %}
+
+{% macro tmpl_var__rule(_name, _value, _tags, _hosts, _kwargs) %}
+{% if _tags %}
+{%   set _formatted_tags = "['" + (_tags | join("', '")) + "', ]" %}
+{% else %}
+{%   set _formatted_tags = "[]" %}
+{% endif %}
 
 {{ _name }} = [
-  ( '{{ _value }}', ['{{ _tags | join("', '") }}', ], ALL_HOSTS, {'description': u'{{ _desc }}'} ),
+  ( {{ "'" + _value + "', " if _value | length > 0 else "" }}{{ _formatted_tags }}, {{ _hosts }}, {{ _kwargs | pprint | replace("\n", "") | regex_replace("(, |{)u'", "\\1'") }} ),
 ] + {{ _name }}
 {% endmacro %}
 

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -37,6 +37,9 @@ checkmk_server__confd_variable_map:
   define_hostgroups:
     filename: 'groups.mk'
     template: 'dict_update_legacy'
+  define_servicegroups:
+    filename: 'groups.mk'
+    template: 'dict_update_legacy'
   inventory_check_interval:
     filename: 'global.mk'
     template: 'key_value'

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -52,6 +52,9 @@ checkmk_server__confd_variable_map:
   host_groups:
     filename: 'rules.mk'
     template: 'rule'
+  ignored_services:
+    filename: 'rules.mk'
+    template: 'rule'
   inventory_check_interval:
     filename: 'global.mk'
     template: 'key_value'

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -23,6 +23,9 @@ checkmk_server__contact_properties: [ 'alias', 'contactgroup',
 checkmk_server__variable_map: '{{ checkmk_server__confd_variable_map |
   combine(checkmk_server__multisite_variable_map, recursive=True) }}'
 
+# List of properties which are allowed as kwargs argument for rules
+checkmk_server__site_rule_kwargs: [ 'comment', 'description', 'disabled', 'docu_url' ]
+
 # Configuration variable definitions for Check_MK conf.d definitions
 checkmk_server__confd_variable_map:
   cmk_inv:

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -28,6 +28,9 @@ checkmk_server__site_rule_kwargs: [ 'comment', 'description', 'disabled', 'docu_
 
 # Configuration variable definitions for Check_MK conf.d definitions
 checkmk_server__confd_variable_map:
+  bulkwalk_hosts:
+    filename: 'rules.mk'
+    template: 'rule'
   cmk_inv:
     filename: 'rules.mk'
     template: 'active_check'
@@ -43,6 +46,12 @@ checkmk_server__confd_variable_map:
   define_servicegroups:
     filename: 'groups.mk'
     template: 'dict_update_legacy'
+  host_contactgroups:
+    filename: 'rules.mk'
+    template: 'rule'
+  host_groups:
+    filename: 'rules.mk'
+    template: 'rule'
   inventory_check_interval:
     filename: 'global.mk'
     template: 'key_value'

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -34,6 +34,9 @@ checkmk_server__confd_variable_map:
   define_contactgroups:
     filename: 'groups.mk'
     template: 'dict_update_legacy'
+  define_hostgroups:
+    filename: 'groups.mk'
+    template: 'dict_update_legacy'
   inventory_check_interval:
     filename: 'global.mk'
     template: 'key_value'

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -55,6 +55,9 @@ checkmk_server__confd_variable_map:
   inventory_check_interval:
     filename: 'global.mk'
     template: 'key_value'
+  service_groups:
+    filename: 'global.mk'
+    template: 'rule'
 
 # Configuration varaible definitions for Check_MK multisite definitions
 checkmk_server__multisite_variable_map:


### PR DESCRIPTION
One of the most important configuration item in Check_MK are the rules. This commit extends the jinja2 macro to support more use cases and migrate some of the default upstream rules to use the macro.
