### PR TITLE
Extend Check_MK server site facts

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -89,6 +89,26 @@ checkmk_server__prerequisite_packages: [ 'apache2' ]
 checkmk_server__site: 'debops'
 
 
+# .. envvar:: checkmk_server__hostname
+#
+# Set Check_MK server DNS hostname (e.g. for agent download, API calls, ...).
+checkmk_server__hostname: '{{ ansible_fqdn }}'
+
+
+# .. envvar:: checkmk_server__site_url
+#
+# Check_MK server site URL.
+checkmk_server__site_url: '{{ ("https://" if checkmk_server__pki else "http://") +
+                               checkmk_server__hostname + "/" +
+                               checkmk_server__site }}'
+
+
+# .. envvar:: checkmk_server__webapi_url
+#
+# WebAPI URL of monitoring site.
+checkmk_server__webapi_url: '{{ checkmk_server__site_url + "/check_mk/webapi.py" }}'
+
+
 # .. envvar:: checkmk_server__runtime_config
 #
 # Check_MK site runtime configuration (``omd config``). Changing

--- a/tasks/site.yml
+++ b/tasks/site.yml
@@ -125,7 +125,7 @@
 - name: Read SSH public key
   command: 'cat {{ checkmk_server__site_home }}/.ssh/id_rsa.pub'
   changed_when: False
-  register: checkmk_server_register_ssh_pubkey
+  register: checkmk_server__register_ssh_public_key
   when: checkmk_server__sshkeys|d()
 
 - name: Wait for the site to be started

--- a/templates/etc/ansible/facts.d/checkmk_server.fact.j2
+++ b/templates/etc/ansible/facts.d/checkmk_server.fact.j2
@@ -1,3 +1,8 @@
-{
-"ssh_publickey": "{{ checkmk_server_register_ssh_pubkey.stdout }}"
-}
+{% set _site_facts = {} %}
+{% set _ = _site_facts.update({checkmk_server__site: {"version": checkmk_server__version_label}}) %}
+{% set _ = _site_facts[checkmk_server__site].update({"site_url": checkmk_server__site_url}) %}
+{% set _ = _site_facts[checkmk_server__site].update({"webapi_url": checkmk_server__webapi_url}) %}
+{% if checkmk_server__register_ssh_public_key.stdout|d() %}
+{%   set _ = _site_facts[checkmk_server__site].update({"ssh_public_key": checkmk_server__register_ssh_public_key.stdout}) %}
+{% endif %}
+{{ _site_facts | to_nice_json }}


### PR DESCRIPTION
For the agent to be able to register itself at the Check_MK server, it needs to know the WebAPI URL. Set this as an Ansible local fact, so that the agent role can lookup the URL by itself. This is related to debops-contrib/ansible-checkmk_agent#14.

This commit will conflict with debops-contrib/ansible-checkmk_server#15 which will be closed for now.
