### PR TITLE
Create automation role and user account for WebAPI access

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,10 @@ This role requires at least Ansible `v2.0`. To install it, run:
 ansible-galaxy install debops-contrib.checkmk_server
 ```
 
+### Role dependencies
+
+- `debops.secret`
+
 ### Are you using this as a standalone role without DebOps?
 
 You may need to include missing roles from the [DebOps common

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -214,15 +214,17 @@ checkmk_server__multisite_default_wato_aux_tags:
 
 # .. envvar:: checkmk_server__multisite_cfg_roles
 #
-# Multisite user ``roles`` definition.
+# Multisite user ``roles`` configuration.
 checkmk_server__multisite_cfg_roles:
   - name: 'roles'
-    value: '{{ checkmk_server__multisite_default_roles }}'
+    value: '{{ checkmk_server__multisite_default_roles |
+               combine(checkmk_server__multisite_debops_roles, recursive=True) |
+               combine(checkmk_server__multisite_custom_roles, recursive=True) }}'
 
 
 # .. envvar:: checkmk_server__multisite_default_roles
 #
-# Default upstream user roles configuration.
+# Default upstream multisite user role definitions.
 checkmk_server__multisite_default_roles:
   admin:
     alias: 'Administrator'
@@ -238,11 +240,50 @@ checkmk_server__multisite_default_roles:
     permissions: {}
 
 
+# .. envvar:: checkmk_server__multisite_debops_roles
+#
+# Multisite user role definitions used by the Ansible role.
+checkmk_server__multisite_debops_roles:
+  api:
+    alias: 'Automation API'
+    basedon: 'user'
+    permissions:
+      general.see_all: True
+      wato.all_folders: True
+      wato.hosttags: True
+      wato.see_all_folders: True
+      wato.seeall: True
+      wato.use: True
+
+
+# .. envvar:: checkmk_server__multisite_custom_roles
+#
+# Custom multisite user role definitions.
+checkmk_server__multisite_custom_roles: {}
+
+
 # .. envvar:: checkmk_server__multisite_users
 #
 # Locally defined multisite users to be configured. See
 # :ref:`checkmk_server__multisite_users` for more information.
-checkmk_server__multisite_users: {}
+checkmk_server__multisite_users: '{{ checkmk_server__multisite_debops_users |
+                                     combine(checkmk_server__multisite_custom_users, recursive=True) }}'
+
+
+# .. envvar:: checkmk_server__multisite_default_users:
+#
+# Multisite user definitions used by the Ansible role.
+checkmk_server__multisite_debops_users:
+  ansible:
+    alias: 'Automation User used by Ansible'
+    automation_secret: '{{ lookup("password", secret + "/credentials/" + ansible_fqdn + "/checkmk_server/" + checkmk_server__site + "/ansible/secret") }}'
+    roles: [ 'api' ]
+
+
+# .. envvar:: checkmk_server__multisite_custom_users:
+#
+# Custom multisite user definitions.
+checkmk_server__multisite_custom_users: {}
 
 
 # .. envvar:: checkmk_server__multisite_user_defaults

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,6 +1,9 @@
 ---
 
-dependencies: []
+dependencies:
+
+  - role: debops.secret
+
 
 galaxy_info:
 

--- a/tasks/site.yml
+++ b/tasks/site.yml
@@ -167,10 +167,22 @@
   with_items: '{{ checkmk_server__multisite_users|d({})|list }}'
   tags: [ 'role::checkmk_server:multisite' ]
 
+- name: Create Web directory for multisite users
+  file:
+    path: '{{ checkmk_server__site_home }}/var/check_mk/web/{{ item }}'
+    state: directory
+    owner: '{{ checkmk_server__user }}'
+    group: '{{ checkmk_server__group }}'
+    mode: '0770'
+  with_items: '{{ checkmk_server__multisite_users|d({})|list }}'
+
 - name: Create automation.secret
   template:
     src: 'var/check_mk/web/user/automation.secret.j2'
     dest: '{{ checkmk_server__site_home }}/var/check_mk/web/{{ item }}/automation.secret'
+    owner: '{{ checkmk_server__user }}'
+    group: '{{ checkmk_server__group }}'
+    mode: '0660'
   when: ("automation_secret" in checkmk_server__multisite_users[item])
   with_items: '{{ checkmk_server__multisite_users|d({})|list }}'
   tags: [ 'role::checkmk_server:multisite' ]

--- a/tasks/site.yml
+++ b/tasks/site.yml
@@ -167,6 +167,14 @@
   with_items: '{{ checkmk_server__multisite_users|d({})|list }}'
   tags: [ 'role::checkmk_server:multisite' ]
 
+- name: Create automation.secret
+  template:
+    src: 'var/check_mk/web/user/automation.secret.j2'
+    dest: '{{ checkmk_server__site_home }}/var/check_mk/web/{{ item }}/automation.secret'
+  when: ("automation_secret" in checkmk_server__multisite_users[item])
+  with_items: '{{ checkmk_server__multisite_users|d({})|list }}'
+  tags: [ 'role::checkmk_server:multisite' ]
+
 - name: Generate Check_MK WATO multisite definitions
   template:
     src: '{{ lookup("template_src", "etc/check_mk/multisite.d/wato/" + item | basename) }}'

--- a/templates/var/check_mk/web/user/automation.secret.j2
+++ b/templates/var/check_mk/web/user/automation.secret.j2
@@ -1,0 +1,1 @@
+{{ checkmk_server__multisite_users[item].automation_secret }}


### PR DESCRIPTION
For automated agent registration (used by debops-contrib/ansible-checkmk_agent#17) a technical user account with minimal privileges must be created. This PR will add the necessary default configurations.
