### PR TITLE
Extend supported variables with 'snmp_communities'

### DIFF
--- a/templates/macros/checkmk_config.j2
+++ b/templates/macros/checkmk_config.j2
@@ -283,7 +283,7 @@ if {{ _name }} == None:
       (_value | length > 0) and
       (_value != 'None') %}
 {%   set _rule = "'" + _value + "'" %}
-{% elif (_value is mapping) %}
+{% elif (_value is mapping) or (_value is sequence) %}
 {#
  #   Remove unicode hints for dictionary keys.
  #   Substitute lists with tuples: ['foo', 'bar'] -> ('foo', 'bar')

--- a/tests/reference.mk
+++ b/tests/reference.mk
@@ -73,3 +73,8 @@ checkgroup_parameters.setdefault('cpu_load', [])
 checkgroup_parameters['cpu_load'] = [
   ( {'levels_upper': ('absolute', (2.0, 4.0)), 'period': 'wday', 'horizon': 90}, [], ALL_HOSTS ),
 ] + checkgroup_parameters['cpu_load']
+
+
+snmp_communities = [
+  ( ('authPriv', 'md5', 'snmpuser', 'snmppass', 'DES', 'snmppass'), ['imm', 'snmp', ], ALL_HOSTS, {'description': u'IBM IMM SNMP Credentials'} ),
+] + snmp_communities

--- a/tests/reference.mk
+++ b/tests/reference.mk
@@ -78,3 +78,10 @@ checkgroup_parameters['cpu_load'] = [
 snmp_communities = [
   ( ('authPriv', 'md5', 'snmpuser', 'snmppass', 'DES', 'snmppass'), ['imm', 'snmp', ], ALL_HOSTS, {'description': u'IBM IMM SNMP Credentials'} ),
 ] + snmp_communities
+
+
+checkgroup_parameters.setdefault('threads', [])
+
+checkgroup_parameters['threads'] = [
+  ( (4000, 8000), ['physical', ], ALL_HOSTS, {'description': u'Physical servers need to handle a lot of threads'} ),
+] + checkgroup_parameters['threads']

--- a/tests/test_templates.yml
+++ b/tests/test_templates.yml
@@ -110,6 +110,19 @@
               - 4.0
           period: 'wday'
           horizon: 90
+      # rule with tuple value
+      - name: 'snmp_communities'
+        filename: 'rules.mk'
+        template: 'rule'
+        tags: [ 'imm', 'snmp' ]
+        value:
+          - authPriv
+          - md5
+          - snmpuser
+          - snmppass
+          - DES
+          - snmppass
+        description: 'IBM IMM SNMP Credentials'
 
   tasks:
     - template:

--- a/tests/test_templates.yml
+++ b/tests/test_templates.yml
@@ -123,6 +123,16 @@
           - DES
           - snmppass
         description: 'IBM IMM SNMP Credentials'
+      # rule_w_default with tuple value
+      - name: 'checkgroup_parameters'
+        element: 'threads'
+        filename: 'rules.mk'
+        template: 'rule_w_default'
+        value:
+          - 4000
+          - 8000
+        tags: [ 'physical' ]
+        description: 'Physical servers need to handle a lot of threads'
 
   tasks:
     - template:

--- a/tests/test_templates.yml
+++ b/tests/test_templates.yml
@@ -105,9 +105,7 @@
         template: 'rule_w_default'
         value:
           levels_upper:
-            - absolute:
-              - 2.0
-              - 4.0
+            - absolute: [ 2.0, 4.0 ]
           period: 'wday'
           horizon: 90
       # rule with tuple value
@@ -115,22 +113,14 @@
         filename: 'rules.mk'
         template: 'rule'
         tags: [ 'imm', 'snmp' ]
-        value:
-          - authPriv
-          - md5
-          - snmpuser
-          - snmppass
-          - DES
-          - snmppass
+        value: [ 'authPriv', 'md5', 'snmpuser', 'snmppass', 'DES', 'snmppass' ]
         description: 'IBM IMM SNMP Credentials'
       # rule_w_default with tuple value
       - name: 'checkgroup_parameters'
         element: 'threads'
         filename: 'rules.mk'
         template: 'rule_w_default'
-        value:
-          - 4000
-          - 8000
+        value: [ 4000, 8000 ]
         tags: [ 'physical' ]
         description: 'Physical servers need to handle a lot of threads'
 

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -76,6 +76,9 @@ checkmk_server__confd_variable_map:
   service_groups:
     filename: 'global.mk'
     template: 'rule'
+  snmp_community:
+    filename: 'rules.mk'
+    template: 'rule'
   snmp_timing:
     filename: 'rules.mk'
     template: 'rule'


### PR DESCRIPTION
Includes a macro fix for properly formatting tuple `value`.
