### PR TITLE
Setup Multisite Livestatus service

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -163,7 +163,7 @@ checkmk_server__webapi_url: '{{ checkmk_server__site_url + "/check_mk/webapi.py"
 checkmk_server__omd_config: '{{
   checkmk_server__omd_config_email +
   checkmk_server__omd_config_core +
-  checkmk_server__omd_config_livestatus if checkmk_server__multisite_livestatus|d() else []
+  (checkmk_server__omd_config_livestatus if checkmk_server__multisite_livestatus|d() else [])
 }}'
 
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -38,20 +38,64 @@ checkmk_server__patches:
 # .. envvar:: checkmk_server__ferm_dependent_rules
 #
 # Firewall configuration using the ``debops.ferm`` Ansible role.
-checkmk_server__ferm_dependent_rules:
+checkmk_server__ferm_dependent_rules: '{{
+  checkmk_server__ferm_web_rules +
+  checkmk_server__ferm_livestatus_rules if checkmk_server__multisite_livestatus else ""
+}}'
+
+
+# .. envvar:: checkmk_server__ferm_web_rules
+#
+# Firewall configuration for WATO Web access.
+checkmk_server__ferm_web_rules:
   - type: 'accept'
     dport: '{{ [ "http", "https" ] if checkmk_server__pki else [ "http" ] }}'
-    saddr: '{{ checkmk_server__allow }}'
+    saddr: '{{ checkmk_server__web_allow }}'
     accept_any: True
     weight: '40'
     role: 'checkmk_server'
 
 
-# .. envvar:: checkmk_server__allow
+# .. envvar:: checkmk_server__ferm_livestatus_rules
+#
+# Firewall configuration for Multisite Livestatus access.
+checkmk_server__ferm_livestatus_rules:
+  - type: 'accept'
+    dport: '{{ checkmk_server__livestatus_port }}'
+    saddr: '{{ checkmk_server__livestatus_allow }}'
+    accept_any: True
+    weight: '40'
+    role: 'checkmk_server'
+
+
+# .. envvar:: checkmk_server__web_allow
 #
 # List of IP addresses or network CIDR ranges allowed to connect to the
 # Check_MK Web interface. If list is empty, anyone can connect.
-checkmk_server__allow: []
+checkmk_server__web_allow: []
+
+
+# .. envvar:: checkmk_server__livestatus_allow
+#
+# List of IP addresses or network CIDR ranges allowed to connect to the
+# Check_MK Livestatus TCP socket. If list is empty, anyone can connect.
+checkmk_server__livestatus_allow: []
+
+
+# .. envvar:: checkmk_server__etc_services__dependent_list
+#
+# Add entry for Livestatus to :file:`/etc/services` using the
+# `debops.etc_services` role.
+checkmk_server__etc_services__dependent_list:
+  - name: 'check-mk-livestatus'
+    port: '{{ checkmk_server__livestatus_port }}'
+    comment: 'Check_MK server Livestatus'
+
+
+# .. envvar:: checkmk_server__livestatus_port
+#
+# TCP port for Multisite Livestatus socket.
+checkmk_server__livestatus_port: 6557
 
 
 # .. envvar:: checkmk_server__software_inventory
@@ -111,15 +155,41 @@ checkmk_server__webapi_url: '{{ checkmk_server__site_url + "/check_mk/webapi.py"
                                 if checkmk_server__site|d() else "" }}'
 
 
-# .. envvar:: checkmk_server__runtime_config
+# .. envvar:: checkmk_server__omd_config
 #
-# Check_MK site runtime configuration (``omd config``). Changing
-# these values will shutdown Check_MK for reconfiguration.
-checkmk_server__runtime_config:
+# Check_MK site configuration set via :command:`omd config`. Changing these
+# values will shutdown Check_MK during reconfiguration.
+checkmk_server__omd_config: '{{
+  checkmk_server__omd_config_email +
+  checkmk_server__omd_config_core +
+  checkmk_server__omd_config_livestatus if checkmk_server__multisite_livestatus|d() else []
+}}'
+
+
+# .. envvar:: checkmk_server__omd_config_email
+#
+# Administrator email address set via OMD
+checkmk_server__omd_config_email:
   - var: 'ADMIN_MAIL'
     value: 'hostmaster@{{ ansible_domain if ansible_domain else ansible_hostname }}'
+
+
+# .. envvar:: checkmk_server__omd_config_core
+#
+# Monitoring core set via OMD. Possible values: `icinga` or `nagios`.
+checkmk_server__omd_config_core:
   - var: 'CORE'
     value: 'icinga'
+
+
+# .. envvar:: checkmk_server__omd_config_livestatus
+#
+# Livestatus service configuration via OMD.
+checkmk_server__omd_config_livestatus:
+  - var: 'LIVESTATUS_TCP'
+    value: 'on'
+  - var: 'LIVESTATUS_TCP_PORT'
+    value: '{{ checkmk_server__livestatus_port }}'
 
 
 # .. envvar:: checkmk_server__sshkeys
@@ -161,6 +231,13 @@ checkmk_server__ssh_arguments: '-o BatchMode=yes -o StrictHostKeyChecking=no -o 
 # Indicate if this site is a distributed monitoring slave which receives the
 # Check_MK configuration from another Check_MK server instance.
 checkmk_server__multisite_slave: False
+
+
+# .. envvar:: checkmk_server__multisite_livestatus
+#
+# Enable multisite Livestatus service. This is required for distributed
+# monitoring of this site.
+checkmk_server__multisite_livestatus: '{{ True if checkmk_server__multisite_slave|d() else False }}'
 
 
 # .. envvar:: checkmk_server__multisite_config_path

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -158,7 +158,8 @@ checkmk_server__webapi_url: '{{ checkmk_server__site_url + "/check_mk/webapi.py"
 # .. envvar:: checkmk_server__omd_config
 #
 # Check_MK site configuration set via :command:`omd config`. Changing these
-# values will shutdown Check_MK during reconfiguration.
+# values will shutdown Check_MK during reconfiguration. Check
+# :ref:`checkmk_server__ref_omd_config` for more details.
 checkmk_server__omd_config: '{{
   checkmk_server__omd_config_email +
   checkmk_server__omd_config_core +

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -40,7 +40,7 @@ checkmk_server__patches:
 # Firewall configuration using the ``debops.ferm`` Ansible role.
 checkmk_server__ferm_dependent_rules: '{{
   checkmk_server__ferm_web_rules +
-  checkmk_server__ferm_livestatus_rules if checkmk_server__multisite_livestatus else ""
+  (checkmk_server__ferm_livestatus_rules if checkmk_server__multisite_livestatus else [])
 }}'
 
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -449,7 +449,7 @@ checkmk_server__distributed_sites: {}
 #
 # Default sites properties for distributed monitoring.
 checkmk_server__distributed_sites_defaults:
-  user: 'sitesync'
+  username: 'sitesync'
   password: '{{ lookup("password", secret + "/credentials/" + ansible_fqdn + "/checkmk_server/" + checkmk_server__site + "/sitesync/password") }}'
   disabled: False
   disable_wato: True

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -61,7 +61,7 @@ checkmk_server__ferm_web_rules:
 # Firewall configuration for Multisite Livestatus access.
 checkmk_server__ferm_livestatus_rules:
   - type: 'accept'
-    dport: '{{ checkmk_server__livestatus_port }}'
+    dport: [ '{{ checkmk_server__livestatus_port|string }}' ]
     saddr: '{{ checkmk_server__livestatus_allow }}'
     accept_any: True
     weight: '40'

--- a/docs/defaults-configuration.rst
+++ b/docs/defaults-configuration.rst
@@ -9,6 +9,23 @@ and examples for them.
    :local:
    :depth: 1
 
+
+.. _checkmk_server__ref_omd_config:
+
+checkmk_server__omd_config
+--------------------------
+
+:program:`omd` is a command line utility which is used to manage Check_MK
+monitoring sites. Some basic configuration options of the site will be
+set via this tool. These options are defined in
+:envvar:`checkmk_server__omd_config` which is a list of YAML dictionaries,
+each with two key/value pairs defining the OMD property to be set. One key
+has to be ``var`` with the variable name to be set as value. The other
+key has to be ``value`` with the variable value to be set as value.
+
+See :envvar:`checkmk_server__omd_config_core` for an example.
+
+
 .. _checkmk_server__sshkeys:
 
 checkmk_server__sshkeys

--- a/docs/playbooks/checkmk_server.yml
+++ b/docs/playbooks/checkmk_server.yml
@@ -6,6 +6,12 @@
 
   roles:
 
+    - role: debops.etc_services
+      tags: [ 'role::etc_services' ]
+      etc_services__dependent_list:
+        - '{{ checkmk_server__etc_services__dependent_list }}'
+      when: checkmk_server__multisite_livestatus|d()
+
     - role: debops.ferm
       tags: [ 'role::ferm' ]
       ferm__dependent_rules:

--- a/tasks/site.yml
+++ b/tasks/site.yml
@@ -48,10 +48,10 @@
   when: checkmk_server_register_cron.stat.exists
   notify: [ 'Restart Check_MK' ]
 
-- name: Get Check_MK site runtime configuration
+- name: Query OMD configuration
   command: omd config '{{ checkmk_server__site }}' show '{{ item.var }}'
   with_items: '{{ checkmk_server__omd_config }}'
-  register: checkmk_server_register_runtime
+  register: checkmk_server__register_omd_config
   changed_when: False
   always_run: True
   ignore_errors: '{{ ansible_check_mode }}'
@@ -62,19 +62,19 @@
     state: stopped
   when: (not item.stdout == item.item.value) or
         checkmk_server__fact_update|d(False)
-  with_items: '{{ checkmk_server_register_runtime.results
-                  if not "failed" in checkmk_server_register_runtime else [] }}'
+  with_items: '{{ checkmk_server__register_omd_config.results
+                  if not "failed" in checkmk_server__register_omd_config else [] }}'
 
 - name: Run Check_MK site update
   command: omd --force update '{{ checkmk_server__site }}'
   ignore_errors: '{{ ansible_check_mode }}'
   when: checkmk_server__fact_update|d(False)
 
-- name: Set Check_MK site runtime properties
+- name: Set OMD site properties
   command: omd config '{{ checkmk_server__site }}' set '{{ item.item.var }}' '{{ item.item.value }}'
   when: not item.stdout == item.item.value
-  with_items: '{{ checkmk_server_register_runtime.results
-                  if not "failed" in checkmk_server_register_runtime else [] }}'
+  with_items: '{{ checkmk_server__register_omd_config.results
+                  if not "failed" in checkmk_server__register_omd_config else [] }}'
 
 - name: Enable and start Check_MK site
   service:

--- a/tasks/site.yml
+++ b/tasks/site.yml
@@ -50,7 +50,7 @@
 
 - name: Get Check_MK site runtime configuration
   command: omd config '{{ checkmk_server__site }}' show '{{ item.var }}'
-  with_items: '{{ checkmk_server__runtime_config }}'
+  with_items: '{{ checkmk_server__omd_config }}'
   register: checkmk_server_register_runtime
   changed_when: False
   always_run: True

--- a/tasks/site.yml
+++ b/tasks/site.yml
@@ -60,7 +60,7 @@
   service:
     name: 'check-mk-raw-{{ (checkmk_server_register_site_version.stdout.split(" ")[-1] | splitext)[0] }}'
     state: stopped
-  when: (not item.stdout == item.item.value) or
+  when: (not (item.item.value|string) == item.stdout) or
         checkmk_server__fact_update|d(False)
   with_items: '{{ checkmk_server__register_omd_config.results
                   if not "failed" in checkmk_server__register_omd_config else [] }}'
@@ -72,7 +72,7 @@
 
 - name: Set OMD site properties
   command: omd config '{{ checkmk_server__site }}' set '{{ item.item.var }}' '{{ item.item.value }}'
-  when: not item.stdout == item.item.value
+  when: not item.stdout == (item.item.value|string)
   with_items: '{{ checkmk_server__register_omd_config.results
                   if not "failed" in checkmk_server__register_omd_config else [] }}'
 

--- a/tasks/wato.yml
+++ b/tasks/wato.yml
@@ -7,19 +7,25 @@
     url: '{{ checkmk_server__distributed_sites[item].multisiteurl }}/login.py'
     method: POST
     body: '{{ [ "_login=1",
-                "_username=" + (checkmk_server__distributed_sites[item].username if "username" in checkmk_server__distributed_sites[item]
-                                                                                 else checkmk_server__distributed_sites_defaults.username),
-                "_password=" + (checkmk_server__distributed_sites[item].password if "password" in checkmk_server__distributed_sites[item]
-                                                                                 else checkmk_server__distributed_sites_defaults.password),
+                "_username=" + (checkmk_server__distributed_sites[item].username
+                                if "username" in checkmk_server__distributed_sites[item]
+                                else checkmk_server__distributed_sites_defaults.username),
+                "_password=" + (checkmk_server__distributed_sites[item].password
+                                if "password" in checkmk_server__distributed_sites[item]
+                                else checkmk_server__distributed_sites_defaults.password),
                 "_origtarget=automation_login.py",
                 "_plain_error=1" ] | join("&") }}'
     force_basic_auth: yes
-    user: '{{ checkmk_server__distributed_sites[item].username if "username" in checkmk_server__distributed_sites[item]
-                                                               else checkmk_server__distributed_sites_defaults.username }}'
-    password: '{{ checkmk_server__distributed_sites[item].password if "password" in checkmk_server__distributed_sites[item]
-                                                                   else checkmk_server__distributed_sites_defaults.password }}'
+    user: '{{ checkmk_server__distributed_sites[item].username
+              if "username" in checkmk_server__distributed_sites[item]
+              else checkmk_server__distributed_sites_defaults.username }}'
+    password: '{{ checkmk_server__distributed_sites[item].password
+                  if "password" in checkmk_server__distributed_sites[item]
+                  else checkmk_server__distributed_sites_defaults.password }}'
     status_code: 302
-    validate_certs: '{{ not checkmk_server__distributed_sites[item].insecure }}'
+    validate_certs: '{{ not checkmk_server__distributed_sites[item].insecure
+                        if "insecure" in checkmk_server__distributed_sites[item]
+                        else checkmk_server__distributed_sites_defaults.insecure }}'
   register: checkmk_server__register_multisite_login
   ignore_errors: '{{ ansible_check_mode }}'
   when: not item == checkmk_server__site


### PR DESCRIPTION
When Check_MK is used with the distributed monitoring feature, the "master" site will access the distributed sites via Livestatus TCP service to get their check results. This PR enhances the role to setup the Livestatus service in case the site has `checkmk_server__multisite_slave` or `checkmk_server__multisite_livestatus` enabled.

Multiple variable renames were required for this feature to be implemented:
- Old: `checkmk_server__allow`  -> New: `checkmk_server__web_allow`
- Old: `checkmk_server__runtime_config`  -> New: `checkmk_server__omd_config`
